### PR TITLE
Add OPENAI_ORG_ID environment variable for o3 model access

### DIFF
--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -29,6 +29,7 @@ new TldrStack(app, 'TldrStack', {
   slackBotToken: process.env.SLACK_BOT_TOKEN || '',
   slackSigningSecret: process.env.SLACK_SIGNING_SECRET || '',
   openaiApiKey: process.env.OPENAI_API_KEY || '',
+  openaiOrgId: process.env.OPENAI_ORG_ID || '',
   // Add basic environment configuration
   env: {
     account: accountId,

--- a/cdk/env.example
+++ b/cdk/env.example
@@ -9,6 +9,7 @@ SLACK_SIGNING_SECRET=your-signing-secret-here
 # Optional: For testing locally
 SLACK_APP_ID=your-app-id-here
 
-# OpenAI API Key
-# Get this from https://platform.openai.com/api-keys
+# OpenAI API Key and Organization ID
+# Get these from https://platform.openai.com/api-keys
 OPENAI_API_KEY=your-openai-api-key-here
+OPENAI_ORG_ID=your-openai-org-id-here

--- a/cdk/lib/tldr-stack.ts
+++ b/cdk/lib/tldr-stack.ts
@@ -12,6 +12,7 @@ interface TldrStackProps extends cdk.StackProps {
   slackBotToken: string;
   slackSigningSecret: string;
   openaiApiKey: string;
+  openaiOrgId: string;
 }
 
 export class TldrStack extends cdk.Stack {
@@ -66,6 +67,7 @@ export class TldrStack extends cdk.Stack {
       SLACK_BOT_TOKEN: props.slackBotToken,
       SLACK_SIGNING_SECRET: props.slackSigningSecret,
       OPENAI_API_KEY: props.openaiApiKey,
+      OPENAI_ORG_ID: props.openaiOrgId,
       PROCESSING_QUEUE_URL: processingQueue.queueUrl,
     };
 


### PR DESCRIPTION
## Summary
- Add `OPENAI_ORG_ID` environment variable support to CDK stack for proper o3 model access
- Resolves the "organization must be verified" error when making OpenAI API calls

## Changes Made
- **CDK Stack Interface**: Added `openaiOrgId` parameter to `TldrStackProps`
- **Environment Variables**: Added `OPENAI_ORG_ID` to Lambda function environment
- **CDK App**: Updated to read `OPENAI_ORG_ID` from `process.env`
- **Documentation**: Updated `env.example` with the new environment variable

## How to Use
Set the environment variable in your `.env` file:
```bash
OPENAI_ORG_ID=org-d7MlHsIs7CACpL40DtLP00ZI
```

Or set it as a deployment environment variable for production.

## Test Plan
- [x] CDK TypeScript compilation passes
- [x] Environment variable properly flows from CDK app → stack → Lambda functions
- [x] No hardcoded organization IDs in source code

This change enables the bot to use the o3 model by properly authenticating with the verified organization.

🤖 Generated with [Claude Code](https://claude.ai/code)