### PR TITLE
Fix o3 model temperature restriction: remove custom temperature param…

### DIFF
--- a/lambda/src/bot.rs
+++ b/lambda/src/bot.rs
@@ -949,12 +949,13 @@ impl SlackBot {
 
         // Build the o3 chat completion request
         // Note: o3 model requires 'max_completion_tokens' instead of 'max_tokens'
+        // and only supports the default temperature value (1.0)
         // Since the openai-api-rs crate doesn't support max_completion_tokens yet,
         // we'll make the request manually using reqwest
         let request_body = serde_json::json!({
             "model": "o3",
             "messages": prompt,
-            "temperature": if custom_prompt.is_some() { 0.9 } else { 0.3 },
+            // o3 model only supports default temperature (1.0), so we omit this parameter
             "max_completion_tokens": max_output_tokens
         });
 


### PR DESCRIPTION
…eter

The o3 model only supports the default temperature value (1.0) and does not allow custom temperature values like 0.3 or 0.9. This change removes the temperature parameter from o3 API requests to use the default value.

Resolves error: "Unsupported value: 'temperature' does not support 0.9 with this model. Only the default (1) value is supported."

🤖 Generated with [Claude Code](https://claude.ai/code)