### PR TITLE
feat: setup DDD module structure for TLDR lambda

### DIFF
--- a/lambda/src/adapters/messaging/mod.rs
+++ b/lambda/src/adapters/messaging/mod.rs
@@ -1,0 +1,6 @@
+/// Messaging adapters for queue and event handling.
+///
+/// This module contains:
+/// - SQS message adapters
+/// - Event processing adapters
+/// - Message serialization/deserialization

--- a/lambda/src/adapters/mod.rs
+++ b/lambda/src/adapters/mod.rs
@@ -1,0 +1,10 @@
+/// Adapter layer for interface implementations.
+///
+/// This module contains adapters that implement domain interfaces:
+/// - Web adapters (HTTP handlers, API endpoints)
+/// - Messaging adapters (SQS, webhooks)
+/// - Persistence adapters (repositories, data access)
+
+pub mod web;
+pub mod messaging;
+pub mod persistence;

--- a/lambda/src/adapters/persistence/mod.rs
+++ b/lambda/src/adapters/persistence/mod.rs
@@ -1,0 +1,6 @@
+/// Persistence adapters for data access.
+///
+/// This module contains:
+/// - Repository implementations
+/// - Data mapper implementations
+/// - Storage service adapters

--- a/lambda/src/adapters/web/mod.rs
+++ b/lambda/src/adapters/web/mod.rs
@@ -1,0 +1,6 @@
+/// Web adapters for HTTP handling.
+///
+/// This module contains:
+/// - Lambda API Gateway handlers
+/// - HTTP request/response processing
+/// - Slack webhook adapters

--- a/lambda/src/application/handlers/mod.rs
+++ b/lambda/src/application/handlers/mod.rs
@@ -1,0 +1,6 @@
+/// Command and query handlers for the application layer.
+///
+/// This module contains handlers for:
+/// - Command processing
+/// - Query execution
+/// - Event handling

--- a/lambda/src/application/mod.rs
+++ b/lambda/src/application/mod.rs
@@ -1,0 +1,11 @@
+/// Application layer for use cases and application services.
+///
+/// This module contains:
+/// - Use case implementations
+/// - Application services
+/// - Command and query handlers
+/// - Workflow coordination
+
+pub mod services;
+pub mod use_cases;
+pub mod handlers;

--- a/lambda/src/application/services/mod.rs
+++ b/lambda/src/application/services/mod.rs
@@ -1,0 +1,4 @@
+/// Application services for coordinating business logic.
+///
+/// This module contains application-level services that orchestrate
+/// domain operations and external integrations.

--- a/lambda/src/application/use_cases/mod.rs
+++ b/lambda/src/application/use_cases/mod.rs
@@ -1,0 +1,6 @@
+/// Use case implementations for the TLDR application.
+///
+/// This module contains specific use case implementations:
+/// - Summarize channel messages
+/// - Process slash commands
+/// - Handle webhook events

--- a/lambda/src/domains/messaging/mod.rs
+++ b/lambda/src/domains/messaging/mod.rs
@@ -1,0 +1,7 @@
+/// Messaging domain for handling Slack message operations.
+///
+/// This domain contains:
+/// - Message entities and value objects
+/// - Channel management logic
+/// - Message parsing and formatting
+/// - Message retrieval services

--- a/lambda/src/domains/mod.rs
+++ b/lambda/src/domains/mod.rs
@@ -1,0 +1,10 @@
+/// Domain layer for TLDR application following Domain-Driven Design principles.
+///
+/// This module contains the core business logic organized by domain:
+/// - messaging: Handles Slack message operations and channel management
+/// - summarization: Core summarization logic and AI integration
+/// - user_management: User preferences and access control
+
+pub mod messaging;
+pub mod summarization;
+pub mod user_management;

--- a/lambda/src/domains/summarization/mod.rs
+++ b/lambda/src/domains/summarization/mod.rs
@@ -1,0 +1,7 @@
+/// Summarization domain for AI-powered message summarization.
+///
+/// This domain contains:
+/// - Summarization entities and business rules
+/// - AI integration logic
+/// - Prompt generation and management
+/// - Summary formatting and validation

--- a/lambda/src/domains/user_management/mod.rs
+++ b/lambda/src/domains/user_management/mod.rs
@@ -1,0 +1,7 @@
+/// User management domain for handling user preferences and access control.
+///
+/// This domain contains:
+/// - User entities and value objects
+/// - Access control and permissions
+/// - User preference management
+/// - Team and workspace configuration

--- a/lambda/src/infrastructure/aws/mod.rs
+++ b/lambda/src/infrastructure/aws/mod.rs
@@ -1,0 +1,6 @@
+/// AWS services integration.
+///
+/// This module contains AWS service implementations:
+/// - SQS queue management
+/// - Lambda runtime utilities
+/// - Configuration management

--- a/lambda/src/infrastructure/mod.rs
+++ b/lambda/src/infrastructure/mod.rs
@@ -1,0 +1,13 @@
+/// Infrastructure layer for external integrations and technical concerns.
+///
+/// This module contains:
+/// - AWS services integration (SQS, Lambda)
+/// - Slack API client implementations
+/// - OpenAI API client implementations
+/// - Database and storage abstractions
+/// - Logging and monitoring utilities
+
+pub mod aws;
+pub mod slack;
+pub mod openai;
+pub mod persistence;

--- a/lambda/src/infrastructure/openai/mod.rs
+++ b/lambda/src/infrastructure/openai/mod.rs
@@ -1,0 +1,6 @@
+/// OpenAI API integration.
+///
+/// This module contains OpenAI service implementations:
+/// - ChatGPT API client
+/// - Token estimation
+/// - Response parsing and validation

--- a/lambda/src/infrastructure/persistence/mod.rs
+++ b/lambda/src/infrastructure/persistence/mod.rs
@@ -1,0 +1,6 @@
+/// Persistence layer abstractions.
+///
+/// This module contains data persistence implementations:
+/// - Repository patterns
+/// - Data access interfaces
+/// - Storage abstractions

--- a/lambda/src/infrastructure/slack/mod.rs
+++ b/lambda/src/infrastructure/slack/mod.rs
@@ -1,0 +1,6 @@
+/// Slack API integration.
+///
+/// This module contains Slack service implementations:
+/// - Slack API client
+/// - Webhook handling
+/// - Message formatting and parsing

--- a/lambda/src/lib.rs
+++ b/lambda/src/lib.rs
@@ -35,7 +35,13 @@
 ///
 ///     Ok(())
 /// }
-/// // Re-export the module components as a public API
+/// // DDD module structure
+pub mod domains;
+pub mod infrastructure;
+pub mod application;
+pub mod adapters;
+
+// Legacy modules (to be refactored into DDD structure)
 pub mod bot;
 pub mod errors;
 pub mod formatting;


### PR DESCRIPTION
**Summary**
- Establish Domain-Driven Design module structure for TLDR lambda codebase
- Create organized directory structure with domains, infrastructure, application, and adapters layers

**Changes**
- Created `src/domains/` with messaging, summarization, user_management subdomains
- Created `src/infrastructure/` for external integrations (AWS, Slack, OpenAI, persistence)
- Created `src/application/` for use cases, services, and handlers
- Created `src/adapters/` for interface implementations (web, messaging, persistence)
- Updated lib.rs to include new DDD modules while preserving legacy modules

**Impact**
- Provides foundation for Domain-Driven Design refactor
- Maintains backward compatibility with existing code
- Enables gradual migration of functionality into appropriate layers

Resolves #1

🤖 Generated with [Claude Code](https://claude.ai/code)