### PR TITLE
feat: use gpt-5 responses for summaries

### DIFF
--- a/lambda/src/bot.rs
+++ b/lambda/src/bot.rs
@@ -25,14 +25,14 @@ use crate::errors::SlackError;
 use crate::prompt::sanitize_custom_internal;
 use crate::response::create_replace_original_payload;
 
-// o3 model context limits
-const O3_MAX_CONTEXT_TOKENS: usize = 200_000; // 200K token context window
-const O3_MAX_OUTPUT_TOKENS: usize = 100_000; // Maximum output tokens
-const O3_BUFFER_TOKENS: usize = 250; // Buffer to prevent going over limit
+// gpt-5 model context limits
+const GPT5_MAX_CONTEXT_TOKENS: usize = 200_000; // 200K token context window
+const GPT5_MAX_OUTPUT_TOKENS: usize = 100_000; // Maximum output tokens
+const GPT5_BUFFER_TOKENS: usize = 250; // Buffer to prevent going over limit
 const INLINE_IMAGE_MAX_BYTES: usize = 64 * 1024; // 64 KiB threshold for inline images – keep prompt size sensible
 const URL_IMAGE_MAX_BYTES: usize = 20 * 1024 * 1024; // 20 MB max for OpenAI vision URLs
 
-/// Whitelisted image MIME types o3 accepts
+/// Whitelisted image MIME types gpt-5 accepts
 const ALLOWED_IMAGE_MIME: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
 
 /// Returns lowercase, parameter-stripped, canonical mime (`image/jpg` ⇒ `image/jpeg`).
@@ -918,9 +918,9 @@ impl SlackBot {
         info!("Estimated input tokens: {}", estimated_input_tokens);
 
         // Calculate safe max_tokens (with buffer to prevent exceeding context limit)
-        let max_output_tokens = (O3_MAX_CONTEXT_TOKENS - estimated_input_tokens)
-            .saturating_sub(O3_BUFFER_TOKENS) // Ensure we don't underflow
-            .min(O3_MAX_OUTPUT_TOKENS); // Don't exceed maximum allowed output
+        let max_output_tokens = (GPT5_MAX_CONTEXT_TOKENS - estimated_input_tokens)
+            .saturating_sub(GPT5_BUFFER_TOKENS) // Ensure we don't underflow
+            .min(GPT5_MAX_OUTPUT_TOKENS); // Don't exceed maximum allowed output
 
         info!("Calculated max output tokens: {}", max_output_tokens);
 
@@ -931,16 +931,15 @@ impl SlackBot {
             return Ok("The conversation was too large to summarize completely. Here's a partial summary of the most recent messages.".to_string());
         }
 
-        // Build the o3 chat completion request
-        // Note: o3 model requires 'max_completion_tokens' instead of 'max_tokens'
-        // and only supports the default temperature value (1.0)
-        // Since the openai-api-rs crate doesn't support max_completion_tokens yet,
+        // Build the gpt-5 Responses API request
+        // The Responses API uses 'input' with chat messages and 'max_output_tokens'
+        // Since the openai-api-rs crate doesn't support the Responses endpoint yet,
         // we'll make the request manually using reqwest
         let request_body = serde_json::json!({
-            "model": "o3",
-            "messages": prompt,
-            // o3 model only supports default temperature (1.0), so we omit this parameter
-            "max_completion_tokens": max_output_tokens
+            "model": "gpt-5",
+            "input": prompt,
+            // Omit temperature for deterministic summaries
+            "max_output_tokens": max_output_tokens
         });
 
         // Get the OpenAI API key for direct HTTP request
@@ -963,7 +962,7 @@ impl SlackBot {
         }
 
         let response = client
-            .post("https://api.openai.com/v1/chat/completions")
+            .post("https://api.openai.com/v1/responses")
             .headers(headers)
             .json(&request_body)
             .send()
@@ -986,14 +985,24 @@ impl SlackBot {
         })?;
 
         // Extract the text response from JSON
-        if let Some(choices) = response_json.get("choices").and_then(|c| c.as_array()) {
-            if let Some(choice) = choices.first() {
-                if let Some(text) = choice
-                    .get("message")
-                    .and_then(|m| m.get("content"))
-                    .and_then(|c| c.as_str())
+        if let Some(text_arr) = response_json.get("output_text").and_then(|v| v.as_array()) {
+            if let Some(text) = text_arr.first().and_then(|t| t.as_str()) {
+                let formatted_summary = format!("*Summary from #{}*\n\n{}", channel_name, text);
+                Ok(formatted_summary)
+            } else {
+                Err(SlackError::OpenAIError(
+                    "No text in OpenAI response".to_string(),
+                ))
+            }
+        } else if let Some(outputs) = response_json.get("output").and_then(|o| o.as_array()) {
+            if let Some(first) = outputs.first() {
+                if let Some(text) = first
+                    .get("content")
+                    .and_then(|c| c.as_array())
+                    .and_then(|arr| arr.first())
+                    .and_then(|block| block.get("text"))
+                    .and_then(|t| t.as_str())
                 {
-                    // Include channel information in the final summary
                     let formatted_summary = format!("*Summary from #{}*\n\n{}", channel_name, text);
                     Ok(formatted_summary)
                 } else {
@@ -1003,7 +1012,7 @@ impl SlackBot {
                 }
             } else {
                 Err(SlackError::OpenAIError(
-                    "No choices in OpenAI response".to_string(),
+                    "No output in OpenAI response".to_string(),
                 ))
             }
         } else {


### PR DESCRIPTION
## Summary
- replace o3 chat completions with gpt-5 Responses API for Slack conversation summaries
- update model token constants and response parsing for the new endpoint

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_6895e9a57e34832ba4c8324036492c6a