### PR TITLE
docs: refresh deployment and manifest instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Parameters can be combined:
 - Rust (stable, Edition 2024)
 - `cargo-lambda` ≥ 0.17 for local Lambda builds
 - AWS CLI with a profile that can deploy Lambda + SQS
-- Node 18+ & npm (only for the CDK infrastructure)
+- Node 18+ & npm (only for the CDK stack)
 - A Slack workspace & OpenAI API key (and optional OpenAI Org ID)
 
 ### Steps
@@ -98,17 +98,11 @@ $ cargo lambda build --release
 $ cargo lambda watch   # default on :9000
 ```
 
-Invoke the API Lambda locally with a sample payload:
-
-```bash
-$ cargo lambda invoke --data-file test/fixtures/slash_command.json
-```
-
 ---
 
 ## ☁️  Deployment (AWS CDK)
 
-The **`infrastructure/`** folder contains an *AWS CDK* stack that provisions:
+The **`cdk/`** folder contains an *AWS CDK* stack that provisions:
 
 - API Gateway endpoint
 - Two Lambda functions (API + Worker)
@@ -118,9 +112,9 @@ The **`infrastructure/`** folder contains an *AWS CDK* stack that provisions:
 Deploy in one command:
 
 ```bash
-$ cd infrastructure
+$ cd cdk
 $ npm install             # first time only
-$ npm run cdk deploy
+$ npm run deploy
 ```
 
 After the stack is live, copy the API Gateway URL into your Slack slash-command configuration.
@@ -151,8 +145,9 @@ Environment variables (set in Lambda or an `.env` file for local runs):
 │   │   ├─ worker.rs
 │   │   └─ bot.rs  # SlackBot implementation (shared)
 │   └─ Cargo.toml
-├─ infrastructure/  # AWS CDK stack (TypeScript)
-├─ tests/           # Integration & fixture payloads
+├─ cdk/             # AWS CDK stack (TypeScript)
+├─ docs/            # Additional documentation
+├─ slack-app-manifest.yaml.template
 └─ README.md
 ```
 

--- a/SLACK_APP_SETUP.md
+++ b/SLACK_APP_SETUP.md
@@ -34,9 +34,9 @@ Since Slack's configuration token system is not suitable for CI/CD automation, m
    Or check the GitHub Actions deployment logs for "API Gateway URL for Slack manifest"
 
 2. **Update the Manifest File**:
-   - Open `slack-app-manifest.yaml`
-   - Replace all instances of `YOUR-API-ID` with your actual API Gateway ID
-   - The URL format is: `https://<api-id>.execute-api.<region>.amazonaws.com/prod`
+    - Copy `slack-app-manifest.yaml.template` to `slack-app-manifest.yaml`
+    - Replace all instances of `YOUR-API-ID` with your actual API Gateway ID
+    - The URL format is: `https://<api-id>.execute-api.<region>.amazonaws.com/prod`
 
 3. **Apply to Slack**:
    - Go to [api.slack.com/apps](https://api.slack.com/apps)
@@ -70,7 +70,7 @@ Since Slack's configuration token system is not suitable for CI/CD automation, m
 1. Go to [api.slack.com/apps](https://api.slack.com/apps)
 2. Click "Create New App" → "From an app manifest"
 3. Choose your workspace
-4. Paste the contents of `slack-app-manifest.yaml`
+4. Paste the contents of `slack-app-manifest.yaml.template` (after replacing placeholders)
 5. Review and create the app
 6. Install the app to your workspace
 

--- a/docs/SLACK_APP_SETUP.md
+++ b/docs/SLACK_APP_SETUP.md
@@ -24,13 +24,13 @@ The TLDR bot now supports multiple ways to trigger summaries, not just the `/tld
 
 ## 2. Update App Manifest
 
-Use the provided `slack-app-manifest.yaml` to configure your app with all necessary permissions and features:
+Use the provided `slack-app-manifest.yaml.template` to configure your app with all necessary permissions and features:
 
 ```bash
 # In your Slack app settings:
 1. Go to "App Manifest" 
 2. Switch to YAML mode
-3. Paste the contents of slack-app-manifest.yaml
+3. Paste the contents of slack-app-manifest.yaml.template (after replacing placeholders)
 4. Save changes
 ```
 


### PR DESCRIPTION
## Summary
- point deployment docs to the `cdk/` folder and clean up project layout
- clarify Slack app setup to use `slack-app-manifest.yaml.template`

## Testing
- ⚠️ `cargo test --manifest-path lambda/Cargo.toml` *(compilation exceeded time limit)*
- ✅ `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_68a34c35c68c832bbe5f7af2dce14cd5