### PR TITLE
refactor: add core feature modules

### DIFF
--- a/lambda/src/bin/api.rs
+++ b/lambda/src/bin/api.rs
@@ -21,6 +21,7 @@ use serde_json::{Value, json};
 use sha2::Sha256;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tldr::core::config::AppConfig;
+use tldr::core::features::collect;
 use tracing::{error, info};
 use uuid::Uuid;
 
@@ -247,7 +248,7 @@ async fn get_latest_message_ts(
     let slack_bot = SlackBot::new(config).await?;
 
     // Get the most recent message in the channel (limit to 1)
-    let messages = slack_bot.get_last_n_messages(channel_id, 1).await?;
+    let messages = collect::get_last_n_messages(&slack_bot, channel_id, 1).await?;
 
     // Return the timestamp of the most recent message if available
     if let Some(latest_msg) = messages.first() {

--- a/lambda/src/core/features/collect.rs
+++ b/lambda/src/core/features/collect.rs
@@ -1,0 +1,20 @@
+use crate::bot::SlackBot;
+use crate::errors::SlackError;
+use slack_morphism::prelude::SlackHistoryMessage;
+
+/// Retrieve unread messages from a channel.
+pub async fn get_unread_messages(
+    bot: &SlackBot,
+    channel_id: &str,
+) -> Result<Vec<SlackHistoryMessage>, SlackError> {
+    bot.get_unread_messages(channel_id).await
+}
+
+/// Retrieve the last `count` messages from a channel.
+pub async fn get_last_n_messages(
+    bot: &SlackBot,
+    channel_id: &str,
+    count: u32,
+) -> Result<Vec<SlackHistoryMessage>, SlackError> {
+    bot.get_last_n_messages(channel_id, count).await
+}

--- a/lambda/src/core/features/deliver.rs
+++ b/lambda/src/core/features/deliver.rs
@@ -1,0 +1,25 @@
+use crate::bot::SlackBot;
+use crate::errors::SlackError;
+
+/// Send a direct message to a user.
+pub async fn send_dm(bot: &SlackBot, user_id: &str, message: &str) -> Result<(), SlackError> {
+    bot.send_dm(user_id, message).await
+}
+
+/// Send a message to a channel.
+pub async fn send_message_to_channel(
+    bot: &SlackBot,
+    channel_id: &str,
+    message: &str,
+) -> Result<(), SlackError> {
+    bot.send_message_to_channel(channel_id, message).await
+}
+
+/// Replace the original slash command message via response_url.
+pub async fn replace_original_message(
+    bot: &SlackBot,
+    response_url: &str,
+    text: Option<&str>,
+) -> Result<(), SlackError> {
+    bot.replace_original_message(response_url, text).await
+}

--- a/lambda/src/core/features/mod.rs
+++ b/lambda/src/core/features/mod.rs
@@ -1,0 +1,3 @@
+pub mod collect;
+pub mod deliver;
+pub mod summarize;

--- a/lambda/src/core/features/summarize.rs
+++ b/lambda/src/core/features/summarize.rs
@@ -1,0 +1,16 @@
+use crate::bot::SlackBot;
+use crate::core::config::AppConfig;
+use crate::errors::SlackError;
+use slack_morphism::prelude::SlackHistoryMessage;
+
+/// Summarize a collection of messages using the LLM client.
+pub async fn summarize(
+    bot: &mut SlackBot,
+    config: &AppConfig,
+    messages: &[SlackHistoryMessage],
+    channel_id: &str,
+    custom_prompt: Option<&str>,
+) -> Result<String, SlackError> {
+    bot.summarize_messages_with_chatgpt(config, messages, channel_id, custom_prompt)
+        .await
+}

--- a/lambda/src/core/mod.rs
+++ b/lambda/src/core/mod.rs
@@ -1,2 +1,3 @@
 pub mod config;
+pub mod features;
 pub mod models;

--- a/lambda/src/lib.rs
+++ b/lambda/src/lib.rs
@@ -33,6 +33,7 @@
 /// ```no_run
 /// use tldr::SlackBot;
 /// use tldr::core::config::AppConfig;
+/// use tldr::core::features::{collect, summarize};
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -52,9 +53,9 @@
 ///     let mut bot = SlackBot::new(&config).await?;
 ///
 ///     // Get and summarize unread messages in a channel
-///     let messages = bot.get_unread_messages("C12345678").await?;
+///     let messages = collect::get_unread_messages(&bot, "C12345678").await?;
 ///     if !messages.is_empty() {
-///         let summary = bot.summarize_messages_with_chatgpt(&config, &messages, "C12345678", None).await?;
+///         let summary = summarize::summarize(&mut bot, &config, &messages, "C12345678", None).await?;
 ///         println!("Summary: {}", summary);
 ///     }
 ///


### PR DESCRIPTION
## Summary
- extract Slack operations into new `collect`, `summarize`, and `deliver` feature modules
- route worker and API code through these feature helpers for clearer separation
- document feature usage in library example and re-export features via `core`

## Testing
- `./scripts/agent-run-qa.sh`


------
https://chatgpt.com/codex/tasks/task_b_68a69f2b9a20832bb436de68e97d8247