### PR TITLE
Phase 1: Enable AI App events, /slack/events route, and config entrypoints

### DIFF
--- a/slack-app-manifest.yaml.template
+++ b/slack-app-manifest.yaml.template
@@ -29,6 +29,9 @@ features:
 oauth_config:
   scopes:
     bot:
+      - assistant:write
+      - im:history
+      - chat:write
       - channels:history
       - channels:read
       - chat:write
@@ -52,7 +55,9 @@ settings:
     # Replace YOUR-API-ID and YOUR-REGION with your actual values
     request_url: "https://YOUR-API-ID.execute-api.YOUR-REGION.amazonaws.com/prod/slack/events"
     bot_events:
-      - app_home_opened
+      - assistant_thread_started
+      - assistant_thread_context_changed
+      - message.im
   interactivity:
     is_enabled: true
     # Replace YOUR-API-ID and YOUR-REGION with your actual values


### PR DESCRIPTION
Summary
- Implements Phase 1 of Epic #77 and closes #78.
- Adds `/slack/events` handling in API Lambda with Slack signature verification.
- Handles `url_verification` challenge and `event_callback` for `assistant_thread_started` and `message.im`.
- On assistant thread start, sets suggested prompts and posts an initial bot message with a “Configure summary” button.
- Implements `block_actions` handling to open the TLDR configuration modal via `views.open`.
- Extends Slack client with helpers to post Block Kit messages and set assistant suggested prompts.
- Updates Slack app manifests to include AI App scopes and events.

Details
- API (`lambda/src/api/handler.rs`):
  - Detects Slack Events JSON and responds to `url_verification` challenge.
  - Handles `assistant_thread_started`: calls `assistant.threads.setSuggestedPrompts` with [“Summarize unread”, “Summarize last 50”, “Open configuration”], then posts a first reply with an Actions block containing a primary “Configure summary” button.
  - Handles `message.im` and message events for the manual flow: when the user types terms like “customize” or “open config”, posts a message with an “Open config” button to obtain `trigger_id` path.
  - Adds `block_actions` interactive handling: when the “Configure summary” or “Open config” button is clicked, opens the TLDR modal via `views.open`.
- Slack Client (`lambda/src/slack/client.rs`):
  - `post_message_with_blocks(...)` to post messages with Blocks (optionally in-thread).
  - `assistant_set_suggested_prompts(...)` to set AI App thread suggested prompts.
- Manifests:
  - `slack-app-manifest.yaml.template` and `slack-app-manifest.yaml` updated with:
    - Scopes: `assistant:write`, `im:history`, `chat:write` (explicit for clarity alongside existing scopes)
    - Events: `assistant_thread_started`, `assistant_thread_context_changed`, `message.im`
    - `event_subscriptions.request_url` pointing at `/slack/events`

Testing
- Ran `just qa` (fmt, check, clippy pedantic, tests, and CDK build) — all green.
- Unit tests continue to pass; no behavior change to existing slash command or modal submission paths.

Notes & Follow-ups
- This PR focuses on Phase 1 entry points. Subsequent phases will:
  - Parse semantic commands in assistant thread (e.g., “summarize unread”, “summarize last 50”) into `ProcessingTask`.
  - Post status updates and final summary in the thread.
  - Wire thread-level preferences and message metadata for prefill.

Closes #78.