### PR TITLE
fix(deploy): sync GH secrets to SSM + recover from cold-start failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,38 @@ jobs:
           mask-aws-account-id: true
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && steps.configure-aws-oidc.outcome != 'success'
 
+      # The runtime Lambda reads bot token, signing secret, and Anthropic API
+      # key from SSM SecureString parameters. Sync them from GitHub Actions
+      # secrets on every deploy so SSM and GH-secrets-as-source-of-truth never
+      # drift, and so a freshly-added/rotated secret takes effect on the next
+      # Lambda cold start without manual `aws ssm put-parameter` calls.
+      - name: Sync secrets to SSM
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        env:
+          SLACK_BOT_TOKEN:                     ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_SIGNING_SECRET:                ${{ secrets.SLACK_SIGNING_SECRET }}
+          ANTHROPIC_API_KEY:                   ${{ secrets.ANTHROPIC_API_KEY }}
+          SLACK_BOT_TOKEN_PARAMETER_NAME:      ${{ vars.SLACK_BOT_TOKEN_PARAMETER_NAME || '/tldr/slack/bot-token' }}
+          SLACK_SIGNING_SECRET_PARAMETER_NAME: ${{ vars.SLACK_SIGNING_SECRET_PARAMETER_NAME || '/tldr/slack/signing-secret' }}
+          ANTHROPIC_API_KEY_PARAMETER_NAME:    ${{ vars.ANTHROPIC_API_KEY_PARAMETER_NAME || '/tldr/anthropic/api-key' }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${SLACK_BOT_TOKEN:-}" ]      || missing+=("SLACK_BOT_TOKEN")
+          [ -n "${SLACK_SIGNING_SECRET:-}" ] || missing+=("SLACK_SIGNING_SECRET")
+          [ -n "${ANTHROPIC_API_KEY:-}" ]    || missing+=("ANTHROPIC_API_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required GitHub Actions secrets: ${missing[*]}"
+            exit 1
+          fi
+          aws ssm put-parameter --overwrite --type SecureString \
+            --name "$SLACK_BOT_TOKEN_PARAMETER_NAME"      --value "$SLACK_BOT_TOKEN" >/dev/null
+          aws ssm put-parameter --overwrite --type SecureString \
+            --name "$SLACK_SIGNING_SECRET_PARAMETER_NAME" --value "$SLACK_SIGNING_SECRET" >/dev/null
+          aws ssm put-parameter --overwrite --type SecureString \
+            --name "$ANTHROPIC_API_KEY_PARAMETER_NAME"    --value "$ANTHROPIC_API_KEY" >/dev/null
+          echo "Synced SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, ANTHROPIC_API_KEY to SSM."
+
       - name: Deploy with CDK
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         working-directory: ./cdk

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,11 @@ worker split has been removed.
 - `src/index.ts` — Lambda entry point (`AwsLambdaReceiver` + lazy init).
 - `src/app.ts` — Bolt app factory; registers Assistant, style modal, action handlers.
 - `src/config.ts` — Env + SSM Parameter Store loader (cached).
-- `src/handlers/` — Assistant middleware, style modal, summary action buttons.
+- `src/handlers/` — Assistant middleware, style modal, summary action buttons (registered via `handlers/index.ts` barrel).
 - `src/blocks.ts` — Block Kit builders for welcome / help / style modal / confirmations.
 - `src/intent.ts` — Natural-language command parser (`help`, `style`, `clear_style`, `summarize`, `unknown`).
-- `src/security.ts` — Rate limiting, channel-membership check, style validation.
+- `src/loading_messages.ts` — Rotating progress strings shown via `setStatus({ loading_messages })` while a summary streams.
+- `src/security.ts` — Rate limiting, channel-membership check, style validation, generated-text sanitisers.
 - `src/thread_state.ts` — Persists thread state via Slack message metadata.
 - `src/slack/` — Web client wrappers, `chat.*Stream` helpers, generated-text sanitiser, image fetch.
 - `src/ai/` — Anthropic Messages API client (`@anthropic-ai/sdk`), XML-structured prompt builder, image helpers.

--- a/bolt-ts/src/index.ts
+++ b/bolt-ts/src/index.ts
@@ -27,14 +27,23 @@ async function initialize(): Promise<AwsLambdaReceiver> {
   if (receiverPromise) {
     return receiverPromise;
   }
-  receiverPromise = (async (): Promise<AwsLambdaReceiver> => {
+  // If initialization fails (e.g. SSM not yet populated), clear the cached
+  // promise so the next invocation on this warm container retries instead of
+  // re-awaiting the same rejection.
+  const attempt = (async (): Promise<AwsLambdaReceiver> => {
     const config = await loadConfigCached();
     const created = new AwsLambdaReceiver({ signingSecret: config.slackSigningSecret });
     createApp(config, created);
     receiver = created;
     return created;
   })();
-  return receiverPromise;
+  receiverPromise = attempt;
+  attempt.catch(() => {
+    if (receiverPromise === attempt) {
+      receiverPromise = null;
+    }
+  });
+  return attempt;
 }
 
 export const handler = async (


### PR DESCRIPTION
## Summary

The single-Lambda refactor in #118 moved secret loading from Lambda env vars to **SSM SecureString parameters**, but the deploy workflow was never updated to *populate* SSM. When `ANTHROPIC_API_KEY` was added as a GitHub secret today without a manual `aws ssm put-parameter`, the Lambda crashed on every cold start with `SSM parameter ANTHROPIC_API_KEY_PARAMETER_NAME did not contain a value`. API Gateway returned **502** to Slack, which means:

- No welcome blocks on `assistant_thread_started`
- No suggested prompts
- No response to `message.im` (`help`, `summarize`, etc.)
- No interactive buttons

Confirmed by curling the events endpoint directly:
```
< HTTP/2 502
< x-amzn-errortype: InternalServerErrorException
{"message": "Internal server error"}
```

## Two fixes

### 1. `deploy.yml` — sync GH secrets to SSM on every main push
New "Sync secrets to SSM" step runs `aws ssm put-parameter --overwrite --type SecureString` for `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `ANTHROPIC_API_KEY` **before** CDK deploys. GH secrets remain the source of truth; SSM is rebuilt every deploy, so new/rotated secrets land in the Lambda's read path automatically.

> **Note**: requires the `AWS_DEPLOY_ROLE_ARN` IAM role to have `ssm:PutParameter` permission. If it doesn't, the step fails fast with a clear error and you can either grant the permission or `put-parameter` manually once.

### 2. `bolt-ts/src/index.ts` — don't cache a rejected `receiverPromise`
Previously, if cold-start config load threw, the warm container re-awaited the same rejected promise on every subsequent invocation — meaning even after SSM was populated, the live Lambda kept 502'ing until the container was replaced. The promise now clears itself in a `.catch` so the next invocation retries from scratch.

### 3. CLAUDE.md — minor accuracy fix
Adds `src/loading_messages.ts` and the `handlers/index.ts` barrel to the file map.

## Test plan
- [ ] CI passes (`bolt-build`, `bolt-bundle`, `bolt-lint`, `bolt-test`, `cdk-build`, `cdk-lint`)
- [ ] On merge, the "Sync secrets to SSM" step succeeds
- [ ] After deploy, opening the TLDR assistant in Slack shows the welcome message + suggested prompts + message-count dropdown
- [ ] `help` in the assistant returns the help blocks
- [ ] `summarize` produces a streaming summary with Share / Roast / Receipts buttons