### PR TITLE
feat(prompt): rework Choose Violence + enable adaptive thinking on Sonnet 4.6

### DIFF
--- a/bolt-ts/src/ai/anthropic.ts
+++ b/bolt-ts/src/ai/anthropic.ts
@@ -80,6 +80,11 @@ export class LlmClient {
       const response = await this.client.messages.create({
         model: this.model,
         max_tokens: this.maxOutputTokens,
+        // Anthropic's current best practice for Sonnet 4.6: adaptive thinking.
+        // The model decides when and how much to think; budget_tokens is
+        // deprecated on this family. Thinking blocks are emitted separately
+        // from text blocks, so our text-only consumer is unaffected.
+        thinking: { type: 'adaptive' },
         system: prompt.system,
         messages: [
           {
@@ -107,6 +112,7 @@ export class LlmClient {
       stream = this.client.messages.stream({
         model: this.model,
         max_tokens: this.maxOutputTokens,
+        thinking: { type: 'adaptive' },
         system: prompt.system,
         messages: [
           {
@@ -176,8 +182,10 @@ async function* consumeStream(
       if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
         yield { kind: 'text_delta', delta: event.delta.text };
       }
-      // We intentionally ignore other deltas (input_json_delta, thinking_delta,
-      // citations_delta) — they don't apply to summarisation.
+      // We intentionally ignore non-text deltas: thinking_delta and
+      // signature_delta arrive when adaptive thinking is on; input_json_delta
+      // and citations_delta belong to tool use / citations features we don't
+      // use here. Slack should only see the final user-facing summary text.
     }
     // Surfacing finalMessage() so that any deferred error on the stream is
     // raised here as a thrown exception (handled in the outer catch).

--- a/bolt-ts/src/handlers/assistant.ts
+++ b/bolt-ts/src/handlers/assistant.ts
@@ -47,7 +47,7 @@ const DEFAULT_PROMPTS: Array<{ title: string; message: string }> = [
   {
     title: '🔥 Choose Violence',
     message:
-      'summarize with style: be hyper-critical, sarcastic, and roast everyone mercilessly. call out bad takes and dumb ideas.',
+      'summarize with style: maximum chaos mode — be theatrically funny, dramatic, and roast everyone with surgical precision. make it actually funny, not just mean. start every bullet with a verdict emoji: 🔥 hot take, 💀 self-own, 🤡 clown moment, 📉 L taken, 🎯 surprisingly valid, 🚨 red flag, 🍿 drama unfolding, 🧠 galaxy brain, ⚰️ buried by their own argument. in the Summary section, tag each named person with one verdict emoji after their name. end the Summary with a one-line "🏆 MVP: <person>" and "🪦 casualty: <person>" awards. mock-outrage, dramatic gasps, and absurdist commentary encouraged. keep all four sections, real links, and real receipts intact.',
   },
   { title: '📋 Just the Facts', message: 'summarize' },
   {

--- a/docs/enhanced_home_and_prompts.md
+++ b/docs/enhanced_home_and_prompts.md
@@ -35,7 +35,7 @@ We will update the default suggested prompts shown when opening the assistant th
 
 | # | Title | Message | Rationale |
 |---|-------|---------|-----------|
-| 1 | 🔥 Choose Violence | `summarize with style: be hyper-critical, sarcastic, and roast everyone mercilessly. call out bad takes and dumb ideas.` | The killer feature. "Choose Violence" is more evocative than "Roast Mode". |
+| 1 | 🔥 Choose Violence | `summarize with style: maximum chaos mode — be theatrically funny, dramatic, and roast everyone with surgical precision. make it actually funny, not just mean. start every bullet with a verdict emoji: 🔥 hot take, 💀 self-own, 🤡 clown moment, 📉 L taken, 🎯 surprisingly valid, 🚨 red flag, 🍿 drama unfolding, 🧠 galaxy brain, ⚰️ buried by their own argument. in the Summary section, tag each named person with one verdict emoji after their name. end the Summary with a one-line "🏆 MVP: <person>" and "🪦 casualty: <person>" awards. mock-outrage, dramatic gasps, and absurdist commentary encouraged. keep all four sections, real links, and real receipts intact.` | The killer feature. Emoji-graded verdicts, MVP/casualty awards, and theatrical comedy land harder than plain sarcasm. |
 | 2 | 📋 Just the Facts | `summarize` | Basic utility for quick catch-up. Simple but not boring. |
 | 3 | 🕵️ Run the Investigation | `summarize with style: break down by person. what did each person contribute? be specific about who said what.` | Frames the breakdown as detective work. |
 | 4 | 📜 Pull the Receipts | `summarize with style: find contradictions, broken promises, and things people said they would do but didn't. bring the receipts.` | Specific call-outs of hypocrisy drive engagement. |

--- a/docs/user_workflows.md
+++ b/docs/user_workflows.md
@@ -25,7 +25,7 @@ This document describes the primary user interactions for TLDR in the Slack AI S
 **Goal**: Entertain the group with a sarcastic or critical summary.
 
 1. **User Action**: Opens TLDR and clicks the "🔥 Choose Violence" suggested prompt.
-   - *Command sent*: `summarize with style: be hyper-critical, sarcastic, and roast everyone...`
+   - *Command sent*: `summarize with style: maximum chaos mode — be theatrically funny, dramatic, and roast everyone with surgical precision... start every bullet with a verdict emoji (🔥 💀 🤡 📉 🎯 🚨 🍿 🧠 ⚰️)... end the Summary with 🏆 MVP and 🪦 casualty awards...`
 2. **System**:
    - Generates a summary using the "Roast" persona.
    - Posts the result.


### PR DESCRIPTION
## Summary

- 🔥 **Choose Violence** suggested prompt rewritten: now demands theatrically funny (not just mean) roasting, a 9-emoji verdict legend (🔥 hot take, 💀 self-own, 🤡 clown, 📉 L, 🎯 valid, 🚨 red flag, 🍿 drama, 🧠 galaxy brain, ⚰️ buried) prefixing every bullet, per-person emoji ratings in the Summary, and a one-line 🏆 MVP / 🪦 casualty awards close. Stays inside the existing four-section structure so the system prompt's safety/structure invariants still hold.
- 🧠 **Adaptive thinking enabled** on both `messages.create` and `messages.stream` calls — Anthropic's current best practice for Claude Sonnet 4.6. `budget_tokens` is deprecated on this model family; `thinking: { type: 'adaptive' }` lets the model self-pace reasoning, well suited to summarisation + style application + receipt extraction. Streaming consumer already ignores `thinking_delta` / `signature_delta` events, so the Slack-visible stream is unchanged.
- 📚 Docs synced (`docs/enhanced_home_and_prompts.md`, `docs/user_workflows.md`) so the prompts table and workflow example reflect the new copy.

## Test plan

- [x] `just qa` green locally (151/151 tests, bolt + cdk lint + build)
- [ ] CI green on this PR
- [ ] After merge: deploy workflow runs successfully on main
- [ ] Smoke test in Slack: click "🔥 Choose Violence" in an assistant thread, confirm emoji-graded bullets + MVP/casualty awards land in a real summary
- [ ] Sanity check: a plain `summarize` (no style) still produces the standard four-section output

🤖 Generated with [Claude Code](https://claude.com/claude-code)