### PR TITLE
fix(app): membership caching, image parallelism, bounded maps, doc fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ If installation is not possible (e.g., no root in the container), the scripts em
 Quality checks and tests run without external secrets. For local integration runs or deployments, provide:
 
 - `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`
-- `OPENAI_API_KEY` (and optional `OPENAI_ORG_ID`)
+- `ANTHROPIC_API_KEY` (optionally `ANTHROPIC_MODEL` to override the default `claude-sonnet-4-6`)
 
 For CDK workflows, see `cdk/env.example` and create `cdk/.env` accordingly.
 

--- a/bolt-ts/src/blocks.ts
+++ b/bolt-ts/src/blocks.ts
@@ -236,10 +236,12 @@ export function buildFailureBlocks(
 }
 
 function truncateStyle(style: string): string {
-  if (style.length <= 100) {
+  // Count by Unicode code points so we never split an emoji / surrogate pair.
+  const chars = [...style];
+  if (chars.length <= 100) {
     return style;
   }
-  return style.substring(0, 97) + '...';
+  return chars.slice(0, 97).join('') + '...';
 }
 
 /** Help blocks shown when the user types `help` / `?` / "what can you do". */

--- a/bolt-ts/src/security.ts
+++ b/bolt-ts/src/security.ts
@@ -17,8 +17,14 @@ export const MAX_CUSTOM_STYLE_LENGTH = 4000;
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
+/** Sweep expired rate-limit buckets once the map grows past this many users. */
+const RATE_LIMIT_MAX_TRACKED_USERS = 10_000;
 const MAX_MEMBERSHIP_PAGES = 20;
 const MEMBERSHIP_PAGE_SIZE = 1000;
+/** How long a definitive (channel, user) membership result stays cached. */
+const MEMBERSHIP_CACHE_TTL_MS = 60_000;
+/** Hard cap on cached membership entries; the map is cleared when exceeded. */
+const MEMBERSHIP_CACHE_MAX_ENTRIES = 10_000;
 
 const DISALLOWED_STYLE_PATTERNS = [/system\s*:/i, /assistant\s*:/i, /user\s*:/i, /\{\{/];
 
@@ -27,7 +33,27 @@ interface RateLimitBucket {
   count: number;
 }
 
+/**
+ * Per-(warm-container) request counters. Best-effort: limits are not shared
+ * across concurrently running Lambda instances, and expired buckets are swept
+ * lazily once the map grows past {@link RATE_LIMIT_MAX_TRACKED_USERS}.
+ */
 const rateLimitBuckets = new Map<string, RateLimitBucket>();
+
+interface MembershipCacheEntry {
+  result: 'member' | 'not_member';
+  at: number;
+}
+
+/**
+ * Short-TTL cache for channel-membership checks. `conversations.members` can
+ * paginate over thousands of members, so we avoid repeating it for the same
+ * (channel, user) within {@link MEMBERSHIP_CACHE_TTL_MS}. Only definitive
+ * results are cached — `unknown` (transient API error or pagination ceiling)
+ * is never cached, so a blip can't "stick". Per-container, like the rate
+ * limiter.
+ */
+const membershipCache = new Map<string, MembershipCacheEntry>();
 
 export interface SecurityLogger {
   warn(message: string, ...args: unknown[]): void;
@@ -129,6 +155,16 @@ export interface RateLimitDecision {
 }
 
 export function checkSummarizeRateLimit(userId: string, now = Date.now()): RateLimitDecision {
+  // Opportunistically sweep expired buckets so the per-container map can't grow
+  // without bound across many distinct users on a long-lived warm Lambda.
+  if (rateLimitBuckets.size > RATE_LIMIT_MAX_TRACKED_USERS) {
+    for (const [trackedUser, tracked] of rateLimitBuckets) {
+      if (now - tracked.windowStartedAt >= RATE_LIMIT_WINDOW_MS) {
+        rateLimitBuckets.delete(trackedUser);
+      }
+    }
+  }
+
   const bucket = rateLimitBuckets.get(userId);
   if (!bucket || now - bucket.windowStartedAt >= RATE_LIMIT_WINDOW_MS) {
     rateLimitBuckets.set(userId, { windowStartedAt: now, count: 1 });
@@ -150,6 +186,10 @@ export function resetRateLimitForTests(): void {
   rateLimitBuckets.clear();
 }
 
+export function resetMembershipCacheForTests(): void {
+  membershipCache.clear();
+}
+
 export function sanitizeGeneratedSlackText(text: string): string {
   return text
     .replace(/<!(channel|here|everyone)>/g, '`$&`')
@@ -169,10 +209,19 @@ export async function checkChannelMembership(args: {
   channelId: string;
   userId: string;
   logger: SecurityLogger;
+  /** Injectable clock for tests. */
+  now?: number;
 }): Promise<ChannelMembership> {
   const { client, channelId, userId, logger } = args;
   if (!isValidSlackChannelId(channelId)) {
     return 'not_member';
+  }
+
+  const now = args.now ?? Date.now();
+  const cacheKey = `${channelId}:${userId}`;
+  const cached = membershipCache.get(cacheKey);
+  if (cached && now - cached.at < MEMBERSHIP_CACHE_TTL_MS) {
+    return cached.result;
   }
 
   let cursor: string | undefined;
@@ -185,22 +234,37 @@ export async function checkChannelMembership(args: {
       });
 
       if (response.members?.includes(userId)) {
-        return 'member';
+        return rememberMembership(cacheKey, 'member', now);
       }
 
       const nextCursor = response.response_metadata?.next_cursor?.trim();
       if (!nextCursor) {
-        return 'not_member';
+        return rememberMembership(cacheKey, 'not_member', now);
       }
       cursor = nextCursor;
     } catch (error) {
+      // Don't cache transient failures — report unknown, retry next time.
       logger.warn('Failed to verify Slack channel membership before enqueueing work:', error);
       return 'unknown';
     }
   }
 
+  // Pagination ceiling reached: couldn't verify. Don't cache.
   logger.warn('Slack channel membership check exceeded pagination limit');
   return 'unknown';
+}
+
+/** Cache a definitive membership result (bounded; clears wholesale when full). */
+function rememberMembership(
+  key: string,
+  result: 'member' | 'not_member',
+  now: number
+): ChannelMembership {
+  if (membershipCache.size >= MEMBERSHIP_CACHE_MAX_ENTRIES) {
+    membershipCache.clear();
+  }
+  membershipCache.set(key, { result, at: now });
+  return result;
 }
 
 /** Back-compat boolean wrapper around {@link checkChannelMembership}. */

--- a/bolt-ts/src/worker/prompt_builder.ts
+++ b/bolt-ts/src/worker/prompt_builder.ts
@@ -93,52 +93,7 @@ export async function buildSummarizePromptData(
   }
   const receiptPermalinks = receipts.map((r) => r.permalink);
 
-  const images: ImageBlock[] = [];
-  for (const msg of messages) {
-    if (images.length >= MAX_IMAGES_TOTAL) {
-      break;
-    }
-    for (const file of msg.files) {
-      if (images.length >= MAX_IMAGES_TOTAL) {
-        break;
-      }
-      const url = pickFileDownloadUrl(file);
-      if (!url) {
-        continue;
-      }
-      const mimeHint = file.mimeType ?? '';
-      const canonHint = canonicalizeMime(mimeHint);
-      if (canonHint !== '' && !isAllowedImageMime(canonHint)) {
-        continue;
-      }
-
-      try {
-        const head = await fetchImageHead({ url, botToken: args.botToken, fetchImpl });
-        if (head?.contentType) {
-          const headCanon = canonicalizeMime(head.contentType);
-          if (!headCanon.startsWith('image/') || !isAllowedImageMime(headCanon)) {
-            continue;
-          }
-        }
-        if (head?.contentLength && head.contentLength > INLINE_IMAGE_MAX_BYTES) {
-          continue;
-        }
-        const bytes = await downloadImageBytes({
-          url,
-          botToken: args.botToken,
-          maxBytes: INLINE_IMAGE_MAX_BYTES,
-          fetchImpl,
-        });
-        const finalMime = canonHint || 'image/png';
-        if (!isAllowedImageMime(finalMime)) {
-          continue;
-        }
-        images.push(buildImageBlock(finalMime, bytes));
-      } catch {
-        // Skip individual image failures — non-fatal.
-      }
-    }
-  }
+  const images = await fetchInlineImages(collectImageCandidates(messages), args.botToken, fetchImpl);
 
   const prompt = buildBasePrompt({
     channelName,
@@ -201,6 +156,100 @@ export function applySafetyNetSections(
   }
 
   return out;
+}
+
+interface ImageCandidate {
+  url: string;
+  /** Canonicalised MIME hint from Slack file metadata ('' when unknown). */
+  canonHint: string;
+}
+
+/**
+ * Gather downloadable image candidates from messages, in order, applying only
+ * the cheap MIME-hint pre-filter. The expensive HEAD/GET happen later in
+ * {@link fetchInlineImages}.
+ */
+function collectImageCandidates(messages: RecentMessage[]): ImageCandidate[] {
+  const candidates: ImageCandidate[] = [];
+  for (const msg of messages) {
+    for (const file of msg.files) {
+      const url = pickFileDownloadUrl(file);
+      if (!url) {
+        continue;
+      }
+      const canonHint = canonicalizeMime(file.mimeType ?? '');
+      if (canonHint !== '' && !isAllowedImageMime(canonHint)) {
+        continue;
+      }
+      candidates.push({ url, canonHint });
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Download up to {@link MAX_IMAGES_TOTAL} inline images. Candidates are fetched
+ * in parallel batches (HEAD + GET per image) so a message window with many
+ * attachments doesn't serialise the network round-trips. Order is preserved and
+ * individual failures are skipped; we stop once enough images have succeeded.
+ */
+async function fetchInlineImages(
+  candidates: ImageCandidate[],
+  botToken: string,
+  fetchImpl: typeof fetch
+): Promise<ImageBlock[]> {
+  const images: ImageBlock[] = [];
+  for (
+    let i = 0;
+    i < candidates.length && images.length < MAX_IMAGES_TOTAL;
+    i += MAX_IMAGES_TOTAL
+  ) {
+    const batch = candidates.slice(i, i + MAX_IMAGES_TOTAL);
+    const blocks = await Promise.all(
+      batch.map((candidate) => tryFetchImageBlock(candidate, botToken, fetchImpl))
+    );
+    for (const block of blocks) {
+      if (block && images.length < MAX_IMAGES_TOTAL) {
+        images.push(block);
+      }
+    }
+  }
+  return images;
+}
+
+/** Fetch + validate a single image, returning a content block or null on any
+ *  failure (unsupported type, oversize, network error). */
+async function tryFetchImageBlock(
+  candidate: ImageCandidate,
+  botToken: string,
+  fetchImpl: typeof fetch
+): Promise<ImageBlock | null> {
+  try {
+    const head = await fetchImageHead({ url: candidate.url, botToken, fetchImpl });
+    if (head?.contentType) {
+      const headCanon = canonicalizeMime(head.contentType);
+      if (!headCanon.startsWith('image/') || !isAllowedImageMime(headCanon)) {
+        return null;
+      }
+    }
+    if (head?.contentLength && head.contentLength > INLINE_IMAGE_MAX_BYTES) {
+      return null;
+    }
+    const bytes = await downloadImageBytes({
+      url: candidate.url,
+      botToken,
+      maxBytes: INLINE_IMAGE_MAX_BYTES,
+      fetchImpl,
+    });
+    const finalMime = candidate.canonHint || 'image/png';
+    if (!isAllowedImageMime(finalMime)) {
+      return null;
+    }
+    return buildImageBlock(finalMime, bytes);
+  } catch {
+    // Skip individual image failures — non-fatal.
+    return null;
+  }
 }
 
 async function fetchUserNames(

--- a/bolt-ts/tests/blocks.test.ts
+++ b/bolt-ts/tests/blocks.test.ts
@@ -248,6 +248,24 @@ describe('Block Kit builders', () => {
         expect(section.text.text).toContain('Style cleared');
       }
     });
+
+    it('truncates a long style by code point without splitting an emoji', () => {
+      const longEmoji = '😀'.repeat(120);
+      const blocks = buildStyleConfirmationBlocks(longEmoji);
+      const context = blocks.find((b) => b.type === 'context');
+      expect(context).toBeDefined();
+      if (context?.type === 'context') {
+        const textElement = context.elements.find((e) => 'text' in e);
+        expect(textElement).toBeDefined();
+        if (textElement && 'text' in textElement) {
+          const styleSegment = textElement.text.split('Active style: ')[1];
+          // 97 emoji + "..." == 100 code points, with no lone surrogate halves.
+          expect([...styleSegment].length).toBe(100);
+          expect(styleSegment.endsWith('...')).toBe(true);
+          expect(styleSegment.startsWith('😀')).toBe(true);
+        }
+      }
+    });
   });
 
   describe('quick summarize affordances', () => {

--- a/bolt-ts/tests/security.test.ts
+++ b/bolt-ts/tests/security.test.ts
@@ -4,6 +4,7 @@ import {
   isUserMemberOfChannel,
   isValidSlackTimestamp,
   normalizeMessageCount,
+  resetMembershipCacheForTests,
   resetRateLimitForTests,
   sanitizeGeneratedSlackText,
   validateAndSanitizeStyle,
@@ -12,6 +13,7 @@ import {
 describe('security helpers', () => {
   afterEach(() => {
     resetRateLimitForTests();
+    resetMembershipCacheForTests();
   });
 
   it('clamps message counts to the supported range', () => {
@@ -95,5 +97,50 @@ describe('security helpers', () => {
     });
 
     expect(membership).toBe('unknown');
+  });
+
+  it('caches a definitive membership result within the TTL and re-checks after it expires', async () => {
+    const members = jest
+      .fn()
+      .mockResolvedValue({ members: ['U222'], response_metadata: { next_cursor: '' } });
+    const client = { conversations: { members } };
+    const logger = { warn: jest.fn() };
+    const call = (now: number): Promise<string> =>
+      checkChannelMembership({ client, channelId: 'C123456789', userId: 'U222', logger, now });
+
+    expect(await call(1_000)).toBe('member');
+    expect(members).toHaveBeenCalledTimes(1);
+
+    // Within the TTL → served from cache, no extra API call.
+    expect(await call(1_000 + 30_000)).toBe('member');
+    expect(members).toHaveBeenCalledTimes(1);
+
+    // After the TTL → re-checks via the API.
+    expect(await call(1_000 + 61_000)).toBe('member');
+    expect(members).toHaveBeenCalledTimes(2);
+  });
+
+  it('never caches an unknown membership result', async () => {
+    const members = jest.fn().mockRejectedValue(new Error('slack down'));
+    const client = { conversations: { members } };
+    const logger = { warn: jest.fn() };
+    const call = (): Promise<string> =>
+      checkChannelMembership({ client, channelId: 'C123456789', userId: 'U222', logger, now: 1_000 });
+
+    expect(await call()).toBe('unknown');
+    expect(await call()).toBe('unknown');
+    // Both calls hit the API — a transient error is never cached.
+    expect(members).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts expired rate-limit buckets so the map cannot grow unbounded', () => {
+    // Seed enough distinct users to exceed the tracking threshold at t0.
+    for (let i = 0; i < 10_002; i += 1) {
+      checkSummarizeRateLimit(`U${i}`, 1_000);
+    }
+    // A call well past the window triggers a sweep and still behaves correctly.
+    expect(checkSummarizeRateLimit('Ufresh', 1_000 + 61_000).allowed).toBe(true);
+    // A previously-seen user is allowed again (its expired bucket was swept).
+    expect(checkSummarizeRateLimit('U0', 1_000 + 61_000).allowed).toBe(true);
   });
 });

--- a/bolt-ts/tests/worker/prompt_builder.test.ts
+++ b/bolt-ts/tests/worker/prompt_builder.test.ts
@@ -1,4 +1,8 @@
-import { applySafetyNetSections } from '../../src/worker/prompt_builder';
+import type { WebClient } from '@slack/web-api';
+import {
+  applySafetyNetSections,
+  buildSummarizePromptData,
+} from '../../src/worker/prompt_builder';
 
 describe('applySafetyNetSections', () => {
   it('appends Links shared, Image highlights, and Receipts when missing', () => {
@@ -32,5 +36,59 @@ describe('applySafetyNetSections', () => {
     expect(result).toContain('- https://example.com');
     expect(result).toContain('- https://slack.example/archives/C/p1');
     expect(result).toContain('- Images were shared, but nothing stood out enough to describe.');
+  });
+});
+
+describe('buildSummarizePromptData inline images', () => {
+  it('downloads multiple images in parallel and emits them as content blocks', async () => {
+    const client = {
+      conversations: { info: jest.fn().mockResolvedValue({ channel: { name: 'general' } }) },
+      users: { info: jest.fn().mockResolvedValue({ user: { profile: { display_name: 'bob' } } }) },
+      chat: { getPermalink: jest.fn().mockResolvedValue({ permalink: 'https://x.test/p' }) },
+    } as unknown as WebClient;
+
+    // HEAD → image metadata; GET → bytes. One of each per image.
+    const fetchImpl = jest.fn(async (_url: string, init?: { method?: string }) => {
+      if (init?.method === 'HEAD') {
+        return new Response(null, {
+          status: 200,
+          headers: { 'content-type': 'image/png', 'content-length': '1024' },
+        });
+      }
+      return new Response(new Uint8Array([1, 2, 3, 4]), {
+        status: 200,
+        headers: { 'content-length': '4' },
+      });
+    });
+
+    const messages = [
+      {
+        ts: '100',
+        user: 'U1',
+        text: 'pic one',
+        files: [{ urlPrivateDownload: 'https://files/1', urlPrivate: null, mimeType: 'image/png' }],
+      },
+      {
+        ts: '101',
+        user: 'U2',
+        text: 'pic two',
+        files: [{ urlPrivateDownload: 'https://files/2', urlPrivate: null, mimeType: 'image/jpeg' }],
+      },
+    ];
+
+    const out = await buildSummarizePromptData({
+      client,
+      botToken: 'xoxb',
+      channelId: 'C1',
+      messages,
+      customStyle: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(out.hasAnyImages).toBe(true);
+    const imageBlocks = out.prompt.userContent.filter((b) => b.type === 'image');
+    expect(imageBlocks).toHaveLength(2);
+    // HEAD + GET for each of the two images.
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
   });
 });

--- a/docs/adr/0002-maintain-stateless-architecture.md
+++ b/docs/adr/0002-maintain-stateless-architecture.md
@@ -1,7 +1,9 @@
 # ADR-0002: Maintain Stateless Architecture
 
 ## Status
-**Accepted**
+**Accepted** _(updated 2026-05: the original SQS worker queue was removed — the
+summarization worker now runs inline in the single Lambda. The stateless
+decision below still holds.)_
 
 ## Date
 2025-12-18
@@ -24,7 +26,8 @@ We will **not** add a persistent database (DynamoDB) to the architecture. The ap
 - **User Preferences:** Custom styles persist only for the current assistant thread (stored in Slack message metadata), not across threads or channels.
 - **No "Unread" Detection:** Without per-user OAuth tokens, the bot cannot detect which messages are unread for a specific user. Summarization defaults to "last N messages."
 - **Development Focus:** Engineering effort focuses on leveraging Slack's interaction payloads and message metadata rather than data modeling and synchronization.
-- **Infrastructure:** No AWS resources beyond Lambda + SQS are required.
+- **Infrastructure:** No AWS resources beyond the Lambda + API Gateway are
+  required (the original SQS worker queue has since been removed).
 
 ## References
 - [ADR-0001: Initial Architecture Assessment](0001-initial-architecture-assessment.md)


### PR DESCRIPTION
## Overview

A code-quality review pass over the app. **Rebased onto `main` after [#124](https://github.com/willtech3/tldr/pull/124) ("assistant UX overhaul") merged** — which independently superseded much of the original version of this PR. The scope is now narrowed to only the fixes #124 did *not* make, adapted to its new APIs.

`just qa` is green: **197 tests, 20 suites** (bolt + cdk build/lint/test).

## What #124 already handled (dropped from this PR)

- **`help` over-match** — #124 fixed it more thoroughly via a `SUMMARIZE_PHRASES` matcher.
- **Streaming double-notify + orphaned message** — #124 fixed it via a cleaner `SummarizeOutcome` return that never throws.
- **`postHere` removal / sanitizer dedup** — #124 deliberately *kept* both, so this PR no longer touches them.

## What this PR adds (survives the rebase)

### 🔵 Robustness / performance
- **Membership-check cache.** Channel membership could re-paginate thousands of members on *every* summarize/share/retry/style action. Added a 60s TTL cache keyed by `channel:user`, built on **#124's tri-state `checkChannelMembership`** — only `member` / `not_member` are cached; `unknown` (transient API error or pagination ceiling) is never cached, so a blip can't stick. — `security.ts`
- **Rate-limit map eviction.** Expired buckets are lazily swept once the per-container map exceeds 10k users, so it can't grow unbounded on a long-lived warm Lambda. Preserves #124's `RateLimitDecision` return shape. — `security.ts`
- **Parallel image downloads.** Inline images now fetch in parallel batches (HEAD+GET concurrently) instead of serially; order preserved, failures still skipped. — `prompt_builder.ts`
- **Emoji-safe truncation.** `truncateStyle` now counts by Unicode code point so it can't split a surrogate pair. — `blocks.ts`

### 📄 Docs
- **AGENTS.md** said `OPENAI_API_KEY`; the app uses `ANTHROPIC_API_KEY`.
- **ADR-0002** said "no resources beyond Lambda + SQS"; the SQS worker was removed.

## ⚠️ Reviewer note

The membership cache is a deliberate trade-off: a user who leaves a channel keeps summarize/share access for up to 60s. Acceptable for this bot's scale and far cheaper than re-paginating on every click; errors and the pagination ceiling are never cached, so an outage can't "stick" a wrong result. To eliminate stale-access risk, set the positive TTL to 0 (keep negative caching) or invalidate on `member_left_channel`.

## Test plan

- [x] `just qa` — 197 tests pass
- New tests: membership cache hit/expiry, never-cache-unknown, rate-limit eviction, parallel image fetch, emoji-safe truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
