### PR TITLE
fix(intent): let open-ended chat through from the first message

### DIFF
--- a/bolt-ts/src/blocks.ts
+++ b/bolt-ts/src/blocks.ts
@@ -77,7 +77,7 @@ export function buildWelcomeBlocks(
         type: 'mrkdwn',
         text:
           "👋 *Hi! I'm TLDR.* I turn busy channels into tight summaries — with links, receipts, and image highlights.\n\n" +
-          'Hit *⚡ Summarize now*, pick a suggested prompt, or just tell me what you want (`catch me up`, `summarize last 200`, …).',
+          'Hit *⚡ Summarize now*, pick a suggested prompt, or just talk to me (`catch me up`, `summarize last 200`, or any question — I chat too).',
       },
     },
     { type: 'divider' },

--- a/bolt-ts/src/intent.ts
+++ b/bolt-ts/src/intent.ts
@@ -9,16 +9,48 @@
  *     "help" or "summarize" without being misrouted)
  *  3. summarize (any phrasing that asks for a summary wins over "help",
  *     so "help me summarize" runs a summary instead of printing the manual)
- *  4. help
+ *  4. help (the bare command or a capability question — not any message
+ *     that merely contains the word "help")
  *  5. unknown (the handler answers it as general chat via the model,
  *     falling back to a friendly nudge on failure — never silence)
+ *
+ * Chat is the default. "tldr" is also this app's NAME, so users address it
+ * in conversation ("hey tldr, can you write a haiku?"); the name only counts
+ * as a summarize command when the message *is* the command ("tldr",
+ * "tldr #general last 50"). Same for bare counts: "last 100" alone is a
+ * command, "in the last 2 weeks I read 3 books" is not.
  */
 
 import { UserIntent } from './types';
 
-/** Phrasings that mean "summarize", beyond the literal verb. */
+/** Phrasings that ask for a summary, wherever they appear in a message. */
 const SUMMARIZE_PHRASES =
-  /summar|tl;?dr|recap|catch\s+me\s+up|fill\s+me\s+in|what\s+did\s+i\s+miss|what\s+happened/i;
+  /summar|recap|catch\s+me\s+up|fill\s+me\s+in|what\s+did\s+i\s+miss|what\s+happened/i;
+
+/** A message that is just "last N [messages]" is a quick summarize command. */
+const BARE_COUNT_COMMAND = /^\s*last\s+\d+(?:\s+(?:messages?|msgs?))?\s*[.!?]*\s*$/i;
+
+/**
+ * True when the message *is* the tl;dr command: bare ("tldr", "tl;dr!") or
+ * followed only by command arguments ("tldr #general", "tldr last 50
+ * please", "tldr with style: be funny"). Any other trailing text means the
+ * user is talking *to* TLDR, not commanding it — that stays general chat,
+ * and greetings like "hey tldr" never anchor as a command at all.
+ */
+function isTldrCommand(text: string): boolean {
+  const lead = text.match(/^\s*tl;?dr\b[\s,:!.?-]*/i);
+  if (!lead) {
+    return false;
+  }
+  const residue = text
+    .slice(lead[0].length)
+    .replace(/\bwith\s+style\s*:[\s\S]*$/i, ' ')
+    .replace(/<#[A-Z0-9]+(?:\|[^>]*)?>/g, ' ')
+    .replace(/\blast\s+\d+\b/gi, ' ')
+    .replace(/\b(?:messages?|msgs?|please|pls|now|here|post\s+here|public|this\s+channel|the\s+channel)\b/gi, ' ')
+    .replace(/[\s,.!?]+/g, '');
+  return residue.length === 0;
+}
 
 /**
  * Parse user intent from message text.
@@ -84,7 +116,8 @@ export function parseUserIntent(text: string): UserIntent {
     targetChannel = channelMatch[1];
   }
 
-  const askedToRun = SUMMARIZE_PHRASES.test(textLower) || count !== null;
+  const askedToRun =
+    SUMMARIZE_PHRASES.test(textLower) || isTldrCommand(text) || BARE_COUNT_COMMAND.test(text);
 
   if (askedToRun) {
     return {
@@ -96,8 +129,13 @@ export function parseUserIntent(text: string): UserIntent {
     };
   }
 
-  // Help intent — word-boundary match so "helpful" doesn't trigger it.
-  if (/\bhelp\b/.test(textLower) || textLower === '?' || textLower.includes('what can')) {
+  // Help intent — the bare command or a capability question. A message that
+  // merely contains the word ("help me write an email") is general chat.
+  if (
+    /^\s*(?:please\s+)?help(?:\s+(?:me|please|pls))?\s*[.!?]*\s*$/i.test(text) ||
+    textLower === '?' ||
+    /\bwhat\s+can\s+(?:you|tldr|this\s+app|it)\b/i.test(textLower)
+  ) {
     return { type: 'help' };
   }
 

--- a/bolt-ts/tests/intent.test.ts
+++ b/bolt-ts/tests/intent.test.ts
@@ -35,6 +35,25 @@ describe('parseUserIntent', () => {
       const result = parseUserIntent('help me summarize this channel');
       expect(result).toMatchObject({ type: 'summarize' });
     });
+
+    it('should recognize bare "help me"', () => {
+      const result = parseUserIntent('help me');
+      expect(result).toEqual({ type: 'help' });
+    });
+
+    it('should answer capability questions addressed by name', () => {
+      const result = parseUserIntent('tldr what can you do');
+      expect(result).toEqual({ type: 'help' });
+    });
+
+    it.each([
+      'help me write an email to my team',
+      'can you help me brainstorm names for a project?',
+      'what can I cook tonight',
+    ])('should leave %j to general chat, not the manual', (phrase) => {
+      const result = parseUserIntent(phrase);
+      expect(result).toEqual({ type: 'unknown' });
+    });
   });
 
   describe('style intent', () => {
@@ -152,6 +171,26 @@ describe('parseUserIntent', () => {
       }
     );
 
+    it.each([
+      'TLDR?',
+      'tldr please',
+      'tldr last 50 messages please',
+      'tldr post here',
+    ])('should treat the bare command %j as summarize', (phrase) => {
+      const result = parseUserIntent(phrase);
+      expect(result).toMatchObject({ type: 'summarize' });
+    });
+
+    it('should parse channel and count given to the tldr command', () => {
+      const result = parseUserIntent('tldr <#C123ABC|general> last 50');
+      expect(result).toMatchObject({ type: 'summarize', targetChannel: 'C123ABC', count: 50 });
+    });
+
+    it('should parse a style override given to the tldr command', () => {
+      const result = parseUserIntent('tldr with style: be funny');
+      expect(result).toMatchObject({ type: 'summarize', styleOverride: 'be funny' });
+    });
+
     it('should parse count alongside natural phrasing', () => {
       const result = parseUserIntent('catch me up on the last 200');
       expect(result).toMatchObject({ type: 'summarize', count: 200 });
@@ -233,6 +272,31 @@ describe('parseUserIntent', () => {
     it('should return unknown for empty string', () => {
       const result = parseUserIntent('');
       expect(result).toEqual({ type: 'unknown' });
+    });
+  });
+
+  describe('open-ended chat from the jump', () => {
+    // "tldr" is the app's name — addressing it must start a conversation,
+    // not hijack the message into a summarize (which dead-ends with
+    // "I don't know which channel you're viewing yet" on a fresh thread).
+    it.each([
+      'hey tldr',
+      'hi tldr!',
+      'hey tldr, can you write a haiku about standups?',
+      'tldr do you know any good lunch spots?',
+    ])('should treat %j as general chat', (phrase) => {
+      const result = parseUserIntent(phrase);
+      expect(result).toEqual({ type: 'unknown' });
+    });
+
+    it('should not treat a conversational "last N" as a summarize command', () => {
+      const result = parseUserIntent('I read 3 books in the last 2 weeks, recommend a 4th?');
+      expect(result).toEqual({ type: 'unknown' });
+    });
+
+    it('should still summarize when an addressed message asks for it', () => {
+      const result = parseUserIntent('hey tldr, catch me up');
+      expect(result).toMatchObject({ type: 'summarize' });
     });
   });
 });


### PR DESCRIPTION
## Problem

Open-ended chat (#125) worked, but the intent router almost never let a first message reach it. Its triggers matched **anywhere** in the text, so the natural ways of addressing the app on first open got hijacked:

| You type | What happened | Should be |
|---|---|---|
| `hey tldr, can you write a haiku?` | summarize → *"I don't know which channel you're viewing yet"* | chat |
| `help me write an email to my team` | help manual | chat |
| `I read 3 books in the last 2 weeks, recommend a 4th?` | summarize | chat |

The first one is the killer: `tl;?dr` matched the app's **own name**, so greeting the bot on a fresh thread (no channel in view) dead-ended in a scolding instead of a conversation.

## Fix

Chat is the default; summarize/help only fire when the message **is** the command, not when it merely contains a trigger word:

- **`isTldrCommand()`** — `tldr`/`tl;dr` counts as summarize only when the rest of the message is command arguments (channel mention, `last N`, `with style: …`, `please`/`post here`/`public`). It strips those and requires nothing to remain. `tldr #general last 50` still summarizes; `tldr do you know any good lunch spots?` chats. Mixed messages keep working: `hey tldr, catch me up` summarizes via the catch-up phrase.
- **Bare-count command** — `last 100` alone stays a quick summarize; a conversational "last 2 weeks" no longer triggers.
- **Help** — requires the bare command (`help`, `help me`, `?`) or a capability question (`what can you do`, `tldr what can you do`).
- **Welcome card** — now says *"…or just talk to me (`catch me up`, `summarize last 200`, or any question — I chat too)"* so chat is discoverable from the jump.

Misroutes into chat are safe by design: the chat system prompt already offers `summarize` when relevant (rule 5), so nothing dead-ends. Catch-up idioms (`recap`, `what happened`, `catch me up`, …) intentionally still summarize wherever they appear.

## Tests

New `open-ended chat from the jump` block pins greeting-by-name → chat, conversational `last N` → chat, addressed summarize requests → summarize, plus command forms of `tldr` (channel/count/style args). All existing intent tests unchanged and green.

`just qa` passes: 229 tests / 22 suites, lint, bundle, terraform fmt+validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)