### PR TITLE
ci: bump actions to Node 24 runtimes ahead of June 16 forced default

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,10 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -47,7 +47,7 @@ jobs:
 
       # ---- Terraform (validation runs on every PR and push; no AWS creds) ----
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.14.5
           terraform_wrapper: false
@@ -71,7 +71,7 @@ jobs:
       - name: Configure AWS credentials with OIDC
         id: configure-aws-oidc
         continue-on-error: true
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -81,7 +81,7 @@ jobs:
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
 
       - name: Configure AWS credentials with access keys
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Why

Every workflow run currently emits:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4, aws-actions/configure-aws-credentials@v4, hashicorp/setup-terraform@v3. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

That forced default lands in 6 days. This bumps each flagged action to a major that natively declares `runs.using: node24` (verified against each tag's `action.yml`).

## What

| Action | From | To | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | Pure node24 bump. Deliberately *not* v6: its credential-persistence rework is unnecessary for this and interacts with `claude-code-action`'s post-checkout git operations. |
| `actions/setup-node` | v4 | v6 | v5/v6 auto-caching changes are inert here — `cache: npm` is explicit and `package.json` has no `packageManager` field. |
| `aws-actions/configure-aws-credentials` | v4 | v6 | **v5 still declares node20** — v6 is the first node24 major. v5's stricter boolean parsing crossed safely (only literal `true` passed); all inputs used (OIDC + access-key fallback) exist in v6. |
| `hashicorp/setup-terraform` | v3 | v4 | node24 is its only breaking change. |

- `node-version: '20'` is intentionally unchanged — that's the project/Lambda runtime (`nodejs20.x`), not the action runtime.
- No `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` needed: all four actions have native node24 majors.
- `claude.yml`'s `claude-code-action@beta` is a composite action — no Node runtime of its own.

## Verification

- `just qa` green locally (build, bundle, lint, 229 tests, `terraform fmt`/`validate`).
- PR check run on this branch must show **no** Node deprecation annotation — that's the gate.
- The deploy half (`terraform apply`) only runs on main, so the first post-merge deploy confirms the AWS-credentials and apply path under the new majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)