### PR TITLE
Fix documentation drift in CLAUDE.md/README and consolidate mention sanitizer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,25 +63,25 @@ worker split has been removed.
 
 ### bolt-ts/ Layout
 - `src/index.ts` — Lambda entry point (`AwsLambdaReceiver` + lazy init).
-- `src/app.ts` — Bolt app factory; registers Assistant, style modal, action handlers.
+- `src/app.ts` — Bolt app factory; registers Assistant, style modal, action, message-shortcut, and channel-mention handlers.
 - `src/config.ts` — Env + SSM Parameter Store loader (cached).
-- `src/handlers/` — Assistant middleware, channel @-mention chat, style modal, summary action buttons (registered via `handlers/index.ts` barrel).
+- `src/handlers/` — Assistant middleware (`assistant.ts`), channel @-mention chat (`mention.ts`), style modal (`style.ts`), summary action buttons (`actions.ts`), the "Summarize Thread" message shortcut (`shortcuts.ts`), and `run_summary.ts` — the shared `guardAndRunSummarization` guard → status → run → follow-ups pipeline every summarization entry point funnels through (registered via `handlers/index.ts` barrel).
 - `src/blocks.ts` — Block Kit builders for welcome / help / style modal / confirmations.
 - `src/intent.ts` — Natural-language command parser (`help`, `style`, `clear_style`, `summarize`, `unknown`). `unknown` messages are answered as general chat via the model.
 - `src/loading_messages.ts` — Rotating progress strings shown via `setStatus({ loading_messages })` while a summary streams.
-- `src/security.ts` — Rate limiting, channel-membership check, style validation, generated-text sanitisers.
+- `src/security.ts` — Rate limiting, channel-membership check, style validation.
 - `src/thread_state.ts` — Persists thread state via Slack message metadata.
-- `src/slack/` — Web client wrappers, `chat.*Stream` helpers, generated-text sanitiser, image fetch.
+- `src/slack/` — Web client wrappers, `chat.*Stream` helpers, the generated-text sanitiser (`sanitize.ts`, the single implementation — import from here rather than duplicating the mention regexes), image fetch.
 - `src/ai/` — Anthropic Messages API client (`@anthropic-ai/sdk`), XML-structured prompt builder, image helpers.
 - `src/worker/` — Inline summarisation pipeline: chunker, link extractor, prompt builder, deliver buttons, streaming orchestrator, top-level `runSummarization`. Also `chat.ts` (`runGeneralChat`), the text-in/text-out chat engine behind both non-command assistant messages and channel `@TLDR` mentions.
-- `tests/` — Jest tests for every module above.
+- `tests/` — Jest tests mirroring the `src/` layout. Known gaps: no tests yet for `app.ts`, `handlers/assistant.ts`, `handlers/run_summary.ts`, or `handlers/style.ts`, and `index.test.ts` covers only `isSlackTimeoutRetry`. Add coverage when touching those modules.
 
 ### Key Design Patterns
 - **Single Lambda** — One Node.js function hosts both the Slack signal layer and the Anthropic streaming worker.
 - **Streaming first** — Set `ENABLE_STREAMING=true` (default) so summaries token-stream into the assistant thread.
 - **Lazy init** — Module-level singletons cache config, the Bolt receiver, and the SSM client across warm Lambda invocations.
-- **Safety net** — `applySafetyNetSections` guarantees every summary contains *Summary / Links shared / Image highlights / Receipts* even if the model omits them.
-- **Error containment** — Streaming failures replace the partial Slack message with a canonical error string via `chat.update` (or delete + repost when update fails).
+- **Safety net** — `applySafetyNetSections` appends any of the *Links shared / Image highlights / Receipts* sections the model omitted. The leading summary prose is requested via the prompt only — no *Summary* header is ever enforced.
+- **Error containment** — On the summary path, streaming failures overwrite the partial Slack message with a canonical error string via `chat.update`, falling back to delete + repost (`streaming.ts` `ensureCanonicalFailure`). The general-chat path (`worker/chat.ts`) instead always deletes the partial message and posts a fresh fallback.
 
 ## Important Guidelines
 
@@ -102,6 +102,7 @@ worker split has been removed.
 - `ENABLE_STREAMING` — `true` / `false` (default `true`).
 - `STREAM_MAX_CHUNK_CHARS` — Per-append chunk size (default 8 000, capped at 12 000).
 - `STREAM_MIN_APPEND_INTERVAL_MS` — Floor between appends (default 500 ms).
+- `LOG_LEVEL` — Optional; `debug` enables Bolt debug logging, anything else (or unset) means info.
 
 For local-only runs the function still accepts direct `SLACK_BOT_TOKEN`,
 `SLACK_SIGNING_SECRET`, and `ANTHROPIC_API_KEY` env vars.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Deployment variables:
 | `ENABLE_STREAMING` | `true` to stream summaries into the thread (recommended, default) |
 | `STREAM_MAX_CHUNK_CHARS` | Per-append chunk size for `chat.appendStream` (default 8 000, max 12 000) |
 | `STREAM_MIN_APPEND_INTERVAL_MS` | Floor between appends to respect rate limits (default 500 ms) |
+| `LOG_LEVEL` | Optional. `debug` enables Bolt debug logging; anything else (or unset) means info |
 | `AWS_ACCOUNT_ID` | Optional. If set, Terraform refuses to apply against any other AWS account |
 
 For local-only runs the Lambda also accepts direct `SLACK_BOT_TOKEN`,
@@ -149,11 +150,11 @@ For local-only runs the Lambda also accepts direct `SLACK_BOT_TOKEN`,
 │   │   ├─ loading_messages.ts
 │   │   ├─ security.ts       # Rate limit, membership check, style validation
 │   │   ├─ thread_state.ts   # Persists state via Slack message metadata
-│   │   ├─ handlers/         # Assistant, style, and action handlers
+│   │   ├─ handlers/         # Assistant, style, action, shortcut, and mention handlers
 │   │   ├─ slack/            # Web client wrappers, streaming helpers, sanitiser
 │   │   ├─ ai/               # Anthropic Messages client + XML-structured prompt + image helpers
 │   │   └─ worker/           # Inline summarisation, chunking, link extraction
-│   └─ tests/                # Jest tests for every module above
+│   └─ tests/                # Jest tests mirroring src/ (see CLAUDE.md for known gaps)
 ├─ terraform/       # Infrastructure as code (Terraform)
 ├─ docs/            # Additional documentation
 └─ README.md

--- a/bolt-ts/src/handlers/actions.ts
+++ b/bolt-ts/src/handlers/actions.ts
@@ -13,7 +13,6 @@ import {
   checkChannelMembership,
   isValidSlackChannelId,
   normalizeMessageCount,
-  sanitizeGeneratedSlackText,
   type ConversationsMembersClient,
 } from '../security';
 import type { ThreadContext } from '../types';
@@ -27,7 +26,7 @@ import {
   type RetrySummaryValue,
 } from '../blocks';
 import { ACTION_SUMMARY_FEEDBACK, type StyleKind } from '../worker/deliver';
-import { truncateForMarkdownBlock } from '../slack/sanitize';
+import { sanitizeGeneratedSlackMrkdwn, truncateForMarkdownBlock } from '../slack/sanitize';
 import { RECEIPTS_STYLE, ROAST_STYLE } from '../styles';
 import {
   buildThreadStateMetadata,
@@ -93,7 +92,7 @@ export function registerActionHandlers(app: App, config: AppConfig): void {
       }
 
       const summaryText = stripSummaryHeader(
-        sanitizeGeneratedSlackText(extractSummaryBody(message))
+        sanitizeGeneratedSlackMrkdwn(extractSummaryBody(message))
       );
       if (summaryText.length === 0) {
         await client.chat.postMessage({

--- a/bolt-ts/src/security.ts
+++ b/bolt-ts/src/security.ts
@@ -190,13 +190,6 @@ export function resetMembershipCacheForTests(): void {
   membershipCache.clear();
 }
 
-export function sanitizeGeneratedSlackText(text: string): string {
-  return text
-    .replace(/<!(channel|here|everyone)>/g, '`$&`')
-    .replace(/<!subteam\^[^>]+>/g, '`$&`')
-    .replace(/<@[UW][A-Z0-9]+>/g, '`$&`');
-}
-
 /**
  * Membership check result. `unknown` means we couldn't verify (API error or
  * pagination limit) — callers should say so instead of falsely telling a

--- a/bolt-ts/tests/security.test.ts
+++ b/bolt-ts/tests/security.test.ts
@@ -6,7 +6,6 @@ import {
   normalizeMessageCount,
   resetMembershipCacheForTests,
   resetRateLimitForTests,
-  sanitizeGeneratedSlackText,
   validateAndSanitizeStyle,
 } from '../src/security';
 
@@ -40,12 +39,6 @@ describe('security helpers', () => {
     expect(denied.allowed).toBe(false);
     expect(denied.retryAfterMs).toBe(59_000);
     expect(checkSummarizeRateLimit('U123', 62_000).allowed).toBe(true);
-  });
-
-  it('sanitizes generated Slack mentions before sharing', () => {
-    expect(sanitizeGeneratedSlackText('Ping <!channel> and <@U123ABC456>')).toBe(
-      'Ping `<!channel>` and `<@U123ABC456>`'
-    );
   });
 
   it('validates Slack timestamps from trusted metadata boundaries', () => {


### PR DESCRIPTION
Fixes six documentation-drift items found during a codebase audit, plus one small code consolidation.

## Documentation fixes

1. **`LOG_LEVEL` documented** — read in `bolt-ts/src/app.ts` (`'debug'` → `LogLevel.DEBUG`, anything else → info) but missing from both CLAUDE.md's env-var list and the README configuration table. Added to both.
2. **Safety-net claim corrected** — CLAUDE.md said `applySafetyNetSections` guarantees a *Summary* section; the code only appends *Links shared / Image highlights / Receipts* when omitted, and never enforces a Summary header. The code's own doc comment confirms the three-section behaviour is intended, so the doc now matches the code.
3. **Handlers list completed** — CLAUDE.md now lists `handlers/shortcuts.ts` (the "Summarize Thread" message shortcut) and `handlers/run_summary.ts` (the shared `guardAndRunSummarization` guard → status → run → follow-ups pipeline), and the `app.ts` line mentions shortcut/mention registration. README's layout comment updated to match.
4. **Error containment clarified** — the summary path overwrites the partial message with a canonical error via `chat.update`, falling back to delete + repost (`streaming.ts` `ensureCanonicalFailure`); the general-chat path (`worker/chat.ts`) always deletes the partial and posts a fresh fallback. CLAUDE.md now describes both.
5. **Test-coverage claim softened** — "Jest tests for every module above" replaced with the actual gaps: no tests for `app.ts`, `handlers/assistant.ts`, `handlers/run_summary.ts`, or `handlers/style.ts`, and `index.test.ts` covers only `isSlackTimeoutRetry`.

## Code change

6. **Sanitizer consolidated** — `sanitizeGeneratedSlackText` in `src/security.ts` duplicated the exact regexes of `sanitizeGeneratedSlackMrkdwn` in `src/slack/sanitize.ts`. Removed the `security.ts` copy, pointed `handlers/actions.ts` at the single implementation, and dropped the now-redundant test (the combined-mention case is already covered by `tests/slack/sanitize.test.ts`). CLAUDE.md now notes `slack/sanitize.ts` is the single sanitizer implementation.

## Verification

- `npm run build`, `npm run bundle`, `npm run lint`, `npm test` — all pass (23 suites, 245 tests).
- `terraform fmt -check` — clean. `terraform validate` could not run in this sandbox (registry.terraform.io blocked by the network proxy); no Terraform files are touched, and CI runs the same gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeyrFCR9DmGZYESfYvYKzn

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeyrFCR9DmGZYESfYvYKzn)_