### PR TITLE
docs: per-entrypoint usage guide + manifest template fixes from live sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,89 @@ TLDR is a serverless Slack bot that turns a wall of unread messages into a conci
 
 ## 🚀 Quick Start
 
-### Using TLDR
-
 1. **Open TLDR** – Click the AI Apps icon in the top-right corner of Slack, then select TLDR.
 2. **Navigate to a channel** – Switch to any channel in Slack's main view.
-3. **Summarize** – Tap *⚡ Summarize now*, click a suggested prompt, or type:
-   - `summarize` (or `catch me up`, `what did I miss`, `tldr`) – Summarize the channel you're viewing
-   - `summarize last 100` – Summarize last 100 messages
-   - `summarize #general` – Summarize a specific channel
-   - `style: write as haiku` – Change the summary style for this thread
-   - `help` – Show available commands
+3. **Summarize** – Tap *⚡ Summarize now* or type `summarize`.
 
-That's it! TLDR automatically tracks which channel you're viewing and summarizes it.
-You can also right-click any message → **Summarize Thread** for a private thread recap,
-or `@TLDR <question>` in any channel it's been invited to for a chat reply in that thread.
+That's it — TLDR tracks which channel you're viewing and summarizes it. The full
+tour of every way in is below.
+
+---
+
+## 📖 Usage Guide
+
+TLDR has four front doors. Pick whichever fits the moment:
+
+| Entrypoint | Where | Best for |
+|------------|-------|----------|
+| [Assistant pane](#-assistant-pane--summaries--chat) | AI Apps sidebar | Summaries, styles, and follow-up chat |
+| [Buttons](#-buttons--the-no-typing-path) | Welcome card & under every summary | Zero-typing workflows |
+| [Summarize Thread](#-summarize-thread-shortcut) | *⋯ More actions* on any message | A private recap of one thread |
+| [`@TLDR` mentions](#-tldr-in-channels) | Any channel the bot is in | Quick questions without leaving the conversation |
+
+### 💬 Assistant pane — summaries & chat
+
+Open TLDR from the AI Apps icon and talk to it in plain English:
+
+```text
+summarize                        → the channel you're currently viewing
+catch me up                      → same thing ("what did I miss" and "tldr" work too)
+summarize last 200               → reach further back
+summarize #design                → a specific channel (you must be a member)
+summarize #design last 25 with style: executive brief
+help                             → the command reference card
+```
+
+Every summary streams in live and always ends with four sections: **Summary**,
+**Links shared**, **Image highlights**, and **Receipts** — permalinks back to the
+messages that matter, so you can jump straight to the source.
+
+Anything that *isn't* a command is just conversation. Ask "explain the RFC
+linked above" or "draft a short reply I can post" and TLDR answers in the same
+thread, with the recent thread context in mind.
+
+### ⚡ Buttons — the no-typing path
+
+- **⚡ Summarize now** on the welcome card summarizes the channel you're viewing;
+  the dropdown beside it sets your default message count (5–500, default 50).
+- **🎨 Set style** opens a modal with ready-made personas — 🔥 *Roast*,
+  📜 *Receipts*, 💼 *Executive brief*, 🌸 *Haiku* — or space to write your own
+  (up to 4,000 characters). Save, then hit *⚡ Try it now*.
+- Under every summary: **📤 Share to channel** (asks for confirmation first,
+  posts with your name on it), one-tap **🔥 Roast This** / **📜 Pull Receipts**
+  re-runs, and *Good summary* / *Off the mark* feedback.
+- Every failure comes with a **Retry** button — including *Try last 50* when a
+  channel is too large to summarize in one go.
+
+### 🎨 Styles you can type
+
+Prefer the keyboard? Styles are commands too:
+
+```text
+style: bullet points only, dry humor    → sticks for this thread
+summarize with style: sea shanty        → one-off, doesn't stick
+clear style                             → back to default
+```
+
+### 🧵 Summarize Thread shortcut
+
+Long thread you don't want to scroll? Hover any message → **⋯ More actions** →
+**Summarize Thread**. The recap is ephemeral — only you see it, right there in
+the channel. TLDR needs to be in the channel (`/invite @TLDR`) to read the thread.
+
+### 📣 `@TLDR` in channels
+
+Mention the bot anywhere it's been invited and it replies in that message's
+thread — a quick, streamed chat answer (kept to ~250 words) without anyone
+switching to the assistant pane:
+
+```text
+@TLDR what's the difference between our staging and prod deploy steps?
+@TLDR settle it: tabs or spaces?
+```
+
+Mentions are chat-only — for channel summaries, use the assistant pane, which
+keeps them private to you.
 
 ---
 

--- a/slack-app-manifest.yaml.template
+++ b/slack-app-manifest.yaml.template
@@ -19,6 +19,9 @@ features:
       type: message
       callback_id: summarize_thread
       description: Summarize this message thread
+  assistant_view:
+    assistant_description: TLDR summarizes recent messages from any channel and provides the results in this thread. You can then share summaries with custom style prompts to other channels.
+    suggested_prompts: []
 
 oauth_config:
   scopes:
@@ -28,6 +31,8 @@ oauth_config:
       - channels:history
       - channels:read
       - chat:write
+      # Required by Slack manifest validation whenever shortcuts are declared.
+      - commands
       - files:read
       - groups:history
       - groups:read


### PR DESCRIPTION
## What changed

**README.md** — new **📖 Usage Guide** section documenting all four entrypoints with examples:

- **Assistant pane** — plain-English commands (`summarize`, `catch me up`, `summarize #design last 25 with style: executive brief`, `help`), the chat fallthrough for non-command messages, and the four guaranteed summary sections (Summary / Links shared / Image highlights / Receipts).
- **Buttons** — ⚡ Summarize now, the 5–500 message-count dropdown, the 🎨 Set style modal (🔥 Roast, 📜 Receipts, 💼 Executive brief, 🌸 Haiku presets), 📤 Share to channel, 🔥 Roast This / 📜 Pull Receipts re-runs, feedback, and retry.
- **Summarize Thread shortcut** — ⋯ More actions flow, ephemeral visibility, `/invite @TLDR` requirement.
- **`@TLDR` channel mentions** — chat-only threaded replies (~250 words), added in #128 and now live.

Quick Start is trimmed to three steps that link into the guide. All button labels, preset names, and limits were pulled from `blocks.ts` / `deliver.ts` / `styles.ts` rather than written from memory.

**slack-app-manifest.yaml.template** — two fixes discovered while applying the template to the live Slack app config:

1. Added the `commands` bot scope — Slack's manifest validator rejects any manifest that declares shortcuts without it ("Shortcuts requires the `commands` bot scope"), so the template as previously written could not be saved.
2. Added the `features.assistant_view` section (assistant description + suggested prompts), which the live app relies on for the AI-assistant pane and the template previously omitted — pasting the old template verbatim would have wiped it.

## Why

The live Slack app manifest was synced to this template on 2026-07-12 (adding the `app_mentions:read` scope + `app_mention` event that #128 required, and removing years of drift: dead shortcuts, a deprecated `/tldr` slash command, unused user/canvas scopes, and a `long_description` that still said ChatGPT). The `@TLDR` mention flow was then verified end-to-end in #testing-bots. These docs capture the now-complete feature surface, and the template fixes make it match the validated live config so the next sync is a clean copy-paste.

## Reviewer notes

- `just qa` passes locally (23 suites / 246 tests, terraform fmt + validate).
- Docs/template only — no runtime code changes.
- A separate CLAUDE.md doc-sync task is in flight in another session; if it also touches README, expect a trivial merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)