### PR TITLE
Make TLDR sidebar questions default to model chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ worker split has been removed.
 - **Streaming first** — Set `ENABLE_STREAMING=true` (default) so summaries token-stream into the assistant thread.
 - **Lazy init** — Module-level singletons cache config, the Bolt receiver, and the SSM client across warm Lambda invocations.
 - **Safety net** — `applySafetyNetSections` appends any of the *Links shared / Image highlights / Receipts* sections the model omitted. The leading summary prose is requested via the prompt only — no *Summary* header is ever enforced.
-- **Error containment** — On the summary path, streaming failures overwrite the partial Slack message with a canonical error string via `chat.update`, falling back to delete + repost (`streaming.ts` `ensureCanonicalFailure`). The general-chat path (`worker/chat.ts`) instead always deletes the partial message and posts a fresh fallback.
+- **Error containment** — On the summary path, streaming failures overwrite the partial Slack message with a canonical error string via `chat.update`, falling back to delete + repost (`streaming.ts` `ensureCanonicalFailure`). The general-chat path (`worker/chat.ts`) deletes a partial stream, retries once as a complete model response, and only then posts a failure nudge.
 
 ## Important Guidelines
 

--- a/bolt-ts/src/blocks.ts
+++ b/bolt-ts/src/blocks.ts
@@ -244,7 +244,7 @@ function truncateStyle(style: string): string {
   return chars.slice(0, 97).join('') + '...';
 }
 
-/** Help blocks shown when the user types `help` / `?` / "what can you do". */
+/** Command reference shown when the user types the explicit `help` / `?` command. */
 export function buildHelpBlocks(): KnownBlock[] {
   return [
     {
@@ -283,6 +283,7 @@ export function buildHelpBlocks(): KnownBlock[] {
         text:
           '*⚡ Tips*\n' +
           '• Each summary comes with *📤 Share to channel*, *🔥 Roast This*, and *📜 Pull Receipts* buttons.\n' +
+          '• Ask any ordinary question here and I\'ll answer it as a chat.\n' +
           '• Right-click any message → *Summarize Thread* for an instant, private thread recap.\n' +
           '• `@TLDR <question>` in any channel I\'m in gets a chat reply in that thread.\n' +
           '• Use the dropdown in the welcome message to change how many messages I read.\n' +

--- a/bolt-ts/src/handlers/assistant.ts
+++ b/bolt-ts/src/handlers/assistant.ts
@@ -372,7 +372,8 @@ export function createAssistant(config: AppConfig): Assistant {
           case 'unknown':
           default: {
             // Not a command — treat it as general chat and let the model
-            // answer (it falls back to the old nudge if the call fails).
+            // answer. The chat worker retries a failed stream before showing
+            // a failure nudge.
             const state = await loadThreadStateWithFallback({
               client: client as unknown as SlackWebApiClient,
               assistantChannelId: channelId,

--- a/bolt-ts/src/intent.ts
+++ b/bolt-ts/src/intent.ts
@@ -7,10 +7,9 @@
  *  1. clear/reset/remove style
  *  2. "style: ..." (anchored at start, so instructions may mention
  *     "help" or "summarize" without being misrouted)
- *  3. summarize (any phrasing that asks for a summary wins over "help",
- *     so "help me summarize" runs a summary instead of printing the manual)
- *  4. help (the bare command or a capability question — not any message
- *     that merely contains the word "help")
+ *  3. summarize (an explicit summary request wins over "help", so
+ *     "help me summarize" runs a summary instead of printing the manual)
+ *  4. help (the bare command only — conversational questions go to chat)
  *  5. unknown (the handler answers it as general chat via the model,
  *     falling back to a friendly nudge on failure — never silence)
  *
@@ -23,9 +22,40 @@
 
 import { UserIntent } from './types';
 
-/** Phrasings that ask for a summary, wherever they appear in a message. */
-const SUMMARIZE_PHRASES =
-  /summar|recap|catch\s+me\s+up|fill\s+me\s+in|what\s+did\s+i\s+miss|what\s+happened/i;
+/**
+ * Supported natural-language summary commands. The trailing text is validated
+ * separately so "summarize last 20" remains a command while "summarize how
+ * photosynthesis works" remains an ordinary model query.
+ */
+const SUMMARY_REQUEST_LEAD =
+  /^\s*(?:hey\s+tldr[\s,:!.-]*)?(?:(?:can|could|would|will)\s+you\s+|help\s+me\s+)?(?:please\s+)?(?:summarize|summarise|recap|catch\s+me\s+up|fill\s+me\s+in|what\s+did\s+i\s+miss|what\s+happened|give\s+me\s+(?:a\s+)?(?:summary|recap))\b[\s,:!.-]*/i;
+
+/**
+ * True when a summary verb is being used as a command, not merely discussed
+ * in a question such as "what is abstractive summarization?". Suggested
+ * prompts and typed commands lead with the verb; polite model-style requests
+ * are covered by {@link SUMMARY_REQUEST_LEAD}.
+ */
+function isSummarizeRequest(text: string): boolean {
+  const lead = text.match(SUMMARY_REQUEST_LEAD);
+  if (!lead) {
+    return false;
+  }
+  const residue = text
+    .slice(lead[0].length)
+    .replace(/\bwith\s+style\s*:[\s\S]*$/i, ' ')
+    .replace(/<#[A-Z0-9]+(?:\|[^>]*)?>/g, ' ')
+    .replace(/\blast\s+\d+\b/gi, ' ')
+    .replace(/\bpost\s+here\b/gi, ' ')
+    .replace(/\b(?:this|the|current)\s+channel\b/gi, ' ')
+    .replace(/\bwhat\s+i\s+missed\b/gi, ' ')
+    .replace(
+      /\b(?:messages?|msgs?|please|pls|now|here|public|on|in|from|of|the)\b/gi,
+      ' '
+    )
+    .replace(/[\s,.!?]+/g, '');
+  return residue.length === 0;
+}
 
 /** A message that is just "last N [messages]" is a quick summarize command. */
 const BARE_COUNT_COMMAND = /^\s*last\s+\d+(?:\s+(?:messages?|msgs?))?\s*[.!?]*\s*$/i;
@@ -117,7 +147,7 @@ export function parseUserIntent(text: string): UserIntent {
   }
 
   const askedToRun =
-    SUMMARIZE_PHRASES.test(textLower) || isTldrCommand(text) || BARE_COUNT_COMMAND.test(text);
+    isSummarizeRequest(text) || isTldrCommand(text) || BARE_COUNT_COMMAND.test(text);
 
   if (askedToRun) {
     return {
@@ -129,12 +159,11 @@ export function parseUserIntent(text: string): UserIntent {
     };
   }
 
-  // Help intent — the bare command or a capability question. A message that
-  // merely contains the word ("help me write an email") is general chat.
+  // Help intent — the bare command only. Capability questions and messages
+  // that merely contain the word ("help me write an email") are general chat.
   if (
     /^\s*(?:please\s+)?help(?:\s+(?:me|please|pls))?\s*[.!?]*\s*$/i.test(text) ||
-    textLower === '?' ||
-    /\bwhat\s+can\s+(?:you|tldr|this\s+app|it)\b/i.test(textLower)
+    textLower === '?'
   ) {
     return { type: 'help' };
   }

--- a/bolt-ts/src/worker/chat.ts
+++ b/bolt-ts/src/worker/chat.ts
@@ -9,8 +9,8 @@
  *
  * Both fetch the thread history for context, build a chat prompt, and stream
  * the reply via the same chat.*Stream helpers the summarizer uses. Chat is
- * text in / text out only — no tools, no actions. Failures fall back to a
- * friendly nudge so the user is never left on read.
+ * text in / text out only — no tools, no actions. A failed stream is retried
+ * as a complete model response before the user sees a failure nudge.
  */
 
 import type { WebClient } from '@slack/web-api';
@@ -149,7 +149,18 @@ export async function runGeneralChat(args: GeneralChatArgs): Promise<ChatOutcome
       return 'delivered';
     }
 
-    return await streamChatReply(args, llm, prompt);
+    try {
+      return await streamChatReply(args, llm, prompt);
+    } catch (error) {
+      // A transient Anthropic SSE failure or Slack streaming transport error
+      // should not turn an ordinary question into a canned response. The
+      // streaming helper has already cleaned up any partial message, so make
+      // one fresh model request and deliver it through chat.postMessage.
+      logger.warn('Streaming chat failed; retrying as a full reply:', error);
+      const reply = await llm.generateSummary(prompt);
+      await postFullReply(args, reply);
+      return 'delivered';
+    }
   } catch (error) {
     logger.error('General chat reply failed:', error);
     try {
@@ -350,8 +361,8 @@ async function streamChatReply(
       throw new Error('Anthropic chat stream completed without any output');
     }
   } catch (error) {
-    // Stop and remove the partial (or empty) message before surfacing the
-    // failure fallback.
+    // Stop and remove the partial (or empty) message before the caller retries
+    // delivery as a complete response.
     await stopStream(args.client, {
       channel: args.channelId,
       ts: streamTs,

--- a/bolt-ts/tests/intent.test.ts
+++ b/bolt-ts/tests/intent.test.ts
@@ -21,9 +21,9 @@ describe('parseUserIntent', () => {
       expect(result).toEqual({ type: 'help' });
     });
 
-    it('should recognize "what can you do"', () => {
+    it('should leave a conversational capability question to general chat', () => {
       const result = parseUserIntent('what can you do');
-      expect(result).toEqual({ type: 'help' });
+      expect(result).toEqual({ type: 'unknown' });
     });
 
     it('should not treat "helpful" as help', () => {
@@ -41,9 +41,9 @@ describe('parseUserIntent', () => {
       expect(result).toEqual({ type: 'help' });
     });
 
-    it('should answer capability questions addressed by name', () => {
+    it('should leave capability questions addressed by name to general chat', () => {
       const result = parseUserIntent('tldr what can you do');
-      expect(result).toEqual({ type: 'help' });
+      expect(result).toEqual({ type: 'unknown' });
     });
 
     it.each([
@@ -292,6 +292,27 @@ describe('parseUserIntent', () => {
     it('should not treat a conversational "last N" as a summarize command', () => {
       const result = parseUserIntent('I read 3 books in the last 2 weeks, recommend a 4th?');
       expect(result).toEqual({ type: 'unknown' });
+    });
+
+    it.each([
+      'what is abstractive summarization?',
+      'which model summarizes legal text best?',
+      'can you explain the difference between a recap and a retrospective?',
+      'what happened in 1999?',
+      'can you summarize how photosynthesis works?',
+      'give me a recap of Hamlet',
+    ])('should not mistake a question about summaries for a summarize command: %j', (phrase) => {
+      const result = parseUserIntent(phrase);
+      expect(result).toEqual({ type: 'unknown' });
+    });
+
+    it.each([
+      'could you summarize this channel?',
+      'please recap the last 20 messages',
+      'help me summarize what I missed',
+    ])('should still recognize an explicit summary request: %j', (phrase) => {
+      const result = parseUserIntent(phrase);
+      expect(result).toMatchObject({ type: 'summarize' });
     });
 
     it('should still summarize when an addressed message asks for it', () => {

--- a/bolt-ts/tests/worker/chat.test.ts
+++ b/bolt-ts/tests/worker/chat.test.ts
@@ -180,7 +180,7 @@ describe('runGeneralChat (streaming)', () => {
     expect(prompt.userContent[0].text).toContain('#demo');
   });
 
-  it('cleans up the stream and posts the nudge fallback when the model fails mid-stream', async () => {
+  it('cleans up a failed stream and retries with a full model reply', async () => {
     const { client, spies } = makeWebClient();
     const llm = makeLlm(
       makeStream([
@@ -188,12 +188,34 @@ describe('runGeneralChat (streaming)', () => {
         { kind: 'failed', message: 'boom' },
       ])
     );
+    jest.spyOn(llm, 'generateSummary').mockResolvedValue('Recovered model reply.');
+
+    const outcome = await runGeneralChat(baseArgs(client, llm));
+
+    expect(outcome).toBe('delivered');
+    expect(spies.stopStream).toHaveBeenCalled();
+    expect(spies.chatDelete).toHaveBeenCalledWith({ channel: 'D1', ts: '5.5' });
+    expect(llm.generateSummary).toHaveBeenCalledTimes(1);
+    expect(spies.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Recovered model reply.',
+        blocks: [{ type: 'markdown', text: 'Recovered model reply.' }],
+      })
+    );
+    expect(spies.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ text: CHAT_FAILURE_TEXT })
+    );
+  });
+
+  it('only posts the nudge after both streaming and full model attempts fail', async () => {
+    const { client, spies } = makeWebClient();
+    const llm = makeLlm(makeStream([{ kind: 'failed', message: 'stream failed' }]));
+    jest.spyOn(llm, 'generateSummary').mockRejectedValue(new Error('retry failed'));
 
     const outcome = await runGeneralChat(baseArgs(client, llm));
 
     expect(outcome).toBe('failed');
-    expect(spies.stopStream).toHaveBeenCalled();
-    expect(spies.chatDelete).toHaveBeenCalledWith({ channel: 'D1', ts: '5.5' });
+    expect(llm.generateSummary).toHaveBeenCalledTimes(1);
     expect(spies.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({ text: CHAT_FAILURE_TEXT })
     );
@@ -373,6 +395,7 @@ describe('runGeneralChat (channel surface)', () => {
   it('posts a plain-text failure fallback — assistant nudge buttons stay off channels', async () => {
     const { client, spies } = makeWebClient();
     const llm = makeLlm(makeStream([{ kind: 'failed', message: 'boom' }]));
+    jest.spyOn(llm, 'generateSummary').mockRejectedValue(new Error('retry failed'));
 
     const outcome = await runGeneralChat(channelArgs(client, llm));
 


### PR DESCRIPTION
## Summary

- route conversational and capability questions to model chat instead of static command responses
- distinguish explicit channel-summary commands from questions that merely discuss summaries or recaps
- retry failed streaming chat once as a complete model response before showing the failure nudge
- update help copy and contributor documentation to match the behavior

## Validation

- `./scripts/agent-run-qa.sh`
- 23 Jest suites, 255 tests passed
- TypeScript build, bundle, and ESLint passed
- Terraform format and validation passed